### PR TITLE
[MRG] N-scalar output for ImageRegressor Class

### DIFF
--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -216,7 +216,7 @@ class ImageClassifier(ImageSupervised):
         return self.y_encoder.n_classes
 
     def export_autokeras_model(self, model_file_name):
-        """ Creates and Exports the AutoKeras model to the given filename.
+        """Creates and Exports the AutoKeras model to the given filename.
         
         Args:
             model_file_name: A string containing the name of the file to which the model should be saved

--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -342,15 +342,21 @@ class ImageNRegressor(ImageSupervised):
         """
         try:
             # essentially will determine the number output nodes
-            self.num_scalars = y_train.shape[1]
-            return y_train.flatten().reshape(y_train.shape[0], y_train.shape[1])
+            # sets output nodes to y_train.shape[1] if y_train has more than one dimension
+            # otherwise, set it to 1 (similar behavior to ImageRegressor)
+            self.num_scalars = y_train.shape[1] if 1 < len(y_train.shape) else 1
+            return y_train.flatten().reshape(y_train.shape[0], self.num_scalars)
         except ValueError:
             raise ValueError("ImageNRegressor.transform_y() cannot reshape {}. Must be shape (examples, N).")
 
     def inverse_transform_y(self, output):
-        """Output is expected to be the shape (examples, N)
+        """Output is expected to be the shape (samples, N).
+        If N=1, then output is flattned to be the shape (samples,). When N=1, the model is practically equivalent
+        to ImageRegressor() class.
         """
-        return output
+        # if num_scalars is 1, the model performs like ImageRegressor
+        # so return a flattened result
+        return output if self.num_scalars != 1 else output.flatten()
 
     def export_autokeras_model(self, model_file_name):
         """Creates and Exports the AutoKeras model to the given file path and filenmae. 

--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -313,6 +313,58 @@ class ImageRegressor3D(ImageRegressor):
         kwargs['augment'] = False
         super().__init__(**kwargs)
 
+class ImageNRegressor(ImageSupervised):
+    """ImageNRegressor class.
+
+    It is used for image regression. It searches convolutional neural network architectures
+    for the best configuration for the image dataset.
+
+    With ImageNRegressor you can have 2 dimensional output (samples, N). This is different than ImageRegressor
+    as its output is (samples, 1).
+    """
+
+    @property
+    def loss(self):
+        return regression_loss
+
+    @property
+    def metric(self):
+        return MSE
+
+    def get_n_output_node(self):
+        return self.num_scalars
+
+    def transform_y(self, y_train):
+        """Transform the parameter y_train by reshaping to shape (examples, )
+        
+        Args:
+            y: list of labels to convert
+        """
+        try:
+            # essentially will determine the number output nodes
+            self.num_scalars = y_train.shape[1]
+            return y_train.flatten().reshape(y_train.shape[0], y_train.shape[1])
+        except ValueError as e:
+            raise ValueError("ImageNRegressor.transform_y() cannot reshape {}. Must be shape (examples, N).")
+
+    def inverse_transform_y(self, output):
+        """Output is expected to be the shape (examples, N)
+        """
+        return output
+
+    def export_autokeras_model(self, model_file_name):
+        """ Creates and Exports the AutoKeras model to the given file path and filenmae. 
+        
+        Args:
+            model_file_name: file path and filename where to save the model.
+        """
+        portable_model = PortableImageRegressor(graph=self.cnn.best_model,
+                                                y_encoder=self.y_encoder,
+                                                data_transformer=self.data_transformer,
+                                                resize_params=self.resize_shape,
+                                                path=self.path)
+        pickle_to_file(portable_model, model_file_name)
+
 
 class PortableImageSupervised(PortableDeepSupervised, ABC):
     def __init__(self, graph, y_encoder, data_transformer, resize_params, verbose=False, path=None):

--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -344,7 +344,7 @@ class ImageNRegressor(ImageSupervised):
             # essentially will determine the number output nodes
             self.num_scalars = y_train.shape[1]
             return y_train.flatten().reshape(y_train.shape[0], y_train.shape[1])
-        except ValueError as e:
+        except ValueError:
             raise ValueError("ImageNRegressor.transform_y() cannot reshape {}. Must be shape (examples, N).")
 
     def inverse_transform_y(self, output):
@@ -353,7 +353,7 @@ class ImageNRegressor(ImageSupervised):
         return output
 
     def export_autokeras_model(self, model_file_name):
-        """ Creates and Exports the AutoKeras model to the given file path and filenmae. 
+        """Creates and Exports the AutoKeras model to the given file path and filenmae. 
         
         Args:
             model_file_name: file path and filename where to save the model.

--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -233,7 +233,7 @@ class ImageClassifier(ImageSupervised):
 
 
 class ImageClassifier1D(ImageClassifier):
-    """ ImageClassifier1D class.
+    """ImageClassifier1D class.
 
     It is used for 1D image classification. It searches convolutional neural network architectures
     for the best configuration for the 1D image dataset.
@@ -245,7 +245,7 @@ class ImageClassifier1D(ImageClassifier):
 
 
 class ImageClassifier3D(ImageClassifier):
-    """ ImageClassifier3D class.
+    """ImageClassifier3D class.
 
     It is used for 3D image classification. It searches convolutional neural network architectures
     for the best configuration for the 1D image dataset.
@@ -281,7 +281,7 @@ class ImageRegressor(ImageSupervised):
         return output.flatten()
 
     def export_autokeras_model(self, model_file_name):
-        """ Creates and Exports the AutoKeras model to the given filename. """
+        """Creates and Exports the AutoKeras model to the given filename. """
         portable_model = PortableImageRegressor(graph=self.cnn.best_model,
                                                 y_encoder=self.y_encoder,
                                                 data_transformer=self.data_transformer,
@@ -291,7 +291,7 @@ class ImageRegressor(ImageSupervised):
 
 
 class ImageRegressor1D(ImageRegressor):
-    """ ImageRegressor1D class.
+    """ImageRegressor1D class.
 
     It is used for 1D image regression. It searches convolutional neural network architectures
     for the best configuration for the 1D image dataset.
@@ -303,7 +303,7 @@ class ImageRegressor1D(ImageRegressor):
 
 
 class ImageRegressor3D(ImageRegressor):
-    """ ImageRegressor3D class.
+    """ImageRegressor3D class.
 
     It is used for 3D image regression. It searches convolutional neural network architectures
     for the best configuration for the 1D image dataset.

--- a/tests/image/test_image_supervised.py
+++ b/tests/image/test_image_supervised.py
@@ -71,12 +71,55 @@ def test_fit_predict(_, _1):
     results = clf.predict(train_x)
     assert len(results) == len(train_y)
 
+    # test expected behavior of ImageNRegressor
+    # train_y is (samples, N), result is (samples, N)
     clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
     train_x = np.random.rand(100, 25, 25, 25, 1)
     train_y = np.random.rand(100, 2)
     clf.fit(train_x, train_y)
     results = clf.predict(train_x)
-    assert results.shape == train_y.shape
+    if not results.shape[0] == train_y.shape[0] and results.shape[1] == train_y.shape[1]:
+        raise AssertionError("ImageNRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
+
+    # test edge behavior of ImageNRegressor
+    # train_y is (samples, N, 1), result is (samples, N)
+    clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+    train_x = np.random.rand(100, 25, 25, 25, 1)
+    train_y = np.random.rand(100, 2, 1)
+    clf.fit(train_x, train_y)
+    results = clf.predict(train_x)
+    if not results.shape[0] == train_y.shape[0] and results.shape[1] == train_y.shape[1]:
+        raise AssertionError("ImageNRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
+
+    # test edge behavior of ImageNRegressor
+    # train_y is samples (samples, 1), result is (samples, 1)
+    clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+    train_x = np.random.rand(100, 25, 25, 25, 1)
+    train_y = np.random.rand(100, 1)
+    clf.fit(train_x, train_y)
+    results = clf.predict(train_x)
+    if not results.shape[0] == train_y.shape[0] and results.shape[1] == train_y.shape[1]:
+        raise AssertionError("ImageNRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
+
+    # test edge behavior of ImageNRegressor
+    # train_y is samples (samples), result is (samples, 1)
+    clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+    train_x = np.random.rand(100, 25, 25, 25, 1)
+    train_y = np.random.rand(100)
+    clf.fit(train_x, train_y)
+    results = clf.predict(train_x)
+    if results.shape[0] != train_y.shape[0]:
+        raise AssertionError("ImageNRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
+    if len(results.shape) != 1:
+        raise AssertionError("ImageNRegressor should behave like ImageRegressor when train_y shape is 1 dimensional. Got output shape of {} but expecting shape (samples,)".format(result.shape))
+
+    # test that a train_y shape (examples, N, M) where M != 1 raises an exception
+    with pytest.raises(ValueError):
+        clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+        train_x = np.random.rand(100, 25, 25, 25, 1)
+        train_y = np.random.rand(100, 2, 2)
+        clf.fit(train_x, train_y)
+        results = clf.predict(train_x)
 
     clean_dir(TEST_TEMP_DIR)
 

--- a/tests/image/test_image_supervised.py
+++ b/tests/image/test_image_supervised.py
@@ -71,6 +71,13 @@ def test_fit_predict(_, _1):
     results = clf.predict(train_x)
     assert len(results) == len(train_y)
 
+    clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+    train_x = np.random.rand(100, 25, 25, 25, 1)
+    train_y = np.random.rand(100, 2)
+    clf.fit(train_x, train_y)
+    results = clf.predict(train_x)
+    assert results.shape == train_y.shape
+
     clean_dir(TEST_TEMP_DIR)
 
 

--- a/tests/image/test_image_supervised.py
+++ b/tests/image/test_image_supervised.py
@@ -71,51 +71,51 @@ def test_fit_predict(_, _1):
     results = clf.predict(train_x)
     assert len(results) == len(train_y)
 
-    # test expected behavior of ImageNRegressor
+    # test expected behavior of ImageRegressor
     # train_y is (samples, N), result is (samples, N)
-    clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+    clf = ImageRegressor(path=TEST_TEMP_DIR, verbose=True)
     train_x = np.random.rand(100, 25, 25, 25, 1)
     train_y = np.random.rand(100, 2)
     clf.fit(train_x, train_y)
     results = clf.predict(train_x)
     if not results.shape[0] == train_y.shape[0] and results.shape[1] == train_y.shape[1]:
-        raise AssertionError("ImageNRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
+        raise AssertionError("ImageRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
 
-    # test edge behavior of ImageNRegressor
+    # test edge behavior of ImageRegressor
     # train_y is (samples, N, 1), result is (samples, N)
-    clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+    clf = ImageRegressor(path=TEST_TEMP_DIR, verbose=True)
     train_x = np.random.rand(100, 25, 25, 25, 1)
     train_y = np.random.rand(100, 2, 1)
     clf.fit(train_x, train_y)
     results = clf.predict(train_x)
     if not results.shape[0] == train_y.shape[0] and results.shape[1] == train_y.shape[1]:
-        raise AssertionError("ImageNRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
+        raise AssertionError("ImageRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
 
-    # test edge behavior of ImageNRegressor
+    # test edge behavior of ImageRegressor
     # train_y is samples (samples, 1), result is (samples, 1)
-    clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+    clf = ImageRegressor(path=TEST_TEMP_DIR, verbose=True)
     train_x = np.random.rand(100, 25, 25, 25, 1)
     train_y = np.random.rand(100, 1)
     clf.fit(train_x, train_y)
     results = clf.predict(train_x)
     if not results.shape[0] == train_y.shape[0] and results.shape[1] == train_y.shape[1]:
-        raise AssertionError("ImageNRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
+        raise AssertionError("ImageRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
 
-    # test edge behavior of ImageNRegressor
+    # test edge behavior of ImageRegressor
     # train_y is samples (samples), result is (samples, 1)
-    clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+    clf = ImageRegressor(path=TEST_TEMP_DIR, verbose=True)
     train_x = np.random.rand(100, 25, 25, 25, 1)
     train_y = np.random.rand(100)
     clf.fit(train_x, train_y)
     results = clf.predict(train_x)
     if results.shape[0] != train_y.shape[0]:
-        raise AssertionError("ImageNRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
+        raise AssertionError("ImageRegressor prediction shape {} not similar to train_y shape {}".format(results.shape, train_y.shape))
     if len(results.shape) != 1:
-        raise AssertionError("ImageNRegressor should behave like ImageRegressor when train_y shape is 1 dimensional. Got output shape of {} but expecting shape (samples,)".format(result.shape))
+        raise AssertionError("ImageRegressor should behave like ImageRegressor when train_y shape is 1 dimensional. Got output shape of {} but expecting shape (samples,)".format(result.shape))
 
     # test that a train_y shape (examples, N, M) where M != 1 raises an exception
     with pytest.raises(ValueError):
-        clf = ImageNRegressor(path=TEST_TEMP_DIR, verbose=True)
+        clf = ImageRegressor(path=TEST_TEMP_DIR, verbose=True)
         train_x = np.random.rand(100, 25, 25, 25, 1)
         train_y = np.random.rand(100, 2, 2)
         clf.fit(train_x, train_y)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-
+import os
 import numpy as np
 
 from autokeras.constant import Constant
@@ -36,7 +36,7 @@ def mocked_requests_get(*args, **kwargs):
 @patch('tempfile.gettempdir', return_value=TEST_TEMP_DIR)
 def test_temp_path_generator(_):
     path = temp_path_generator()
-    assert path == TEST_TEMP_DIR + "/autokeras"
+    assert path == os.path.join(TEST_TEMP_DIR, "autokeras")
 
 
 @patch('autokeras.utils.temp_path_generator', return_value=TEST_TEMP_AUTO_KERAS_DIR)


### PR DESCRIPTION
This pull request resolves #ISSUE_NUMBER.

The details of the pull request:
ImageRegressor was modified to support N output nodes. I found that ImageRegressor's output shape (examples, 1) to be too restrictive.

The modified class supports output shapes of (examples, N). For example, you could train models to crop images; the output would be (examples, 4) where the 4 scalars represent the top, right, bottom, left crop distances.