### PR TITLE
Fix documentation link to source pointing to keras repo

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -259,7 +259,7 @@ def class_to_source_link(cls):
     path += '.py'
     line = inspect.getsourcelines(cls)[-1]
     link = ('https://github.com/keras-team/'
-            'keras/blob/master/' + path + '#L' + str(line))
+            'autokeras/blob/master/' + path + '#L' + str(line))
     return '[[source]](' + link + ')'
 
 


### PR DESCRIPTION
### Which issue(s) does this Pull Request fix?
In the documentation of autokeras.com, on https://autokeras.com/task/, https://autokeras.com/auto_model/, etc... The `[source]` link points to the `keras` repository instead of `autokeras`, resulting in 404 Not Found errors when visiting them.

(note: it seemed easier to propose a fix you guys can merge, rather than posting an issue, so there is no issue number referencing this problem) 

### Pull Request Status 

The pull request is ready to be merged. 

### Details of the Pull Request

Fix link generation to point to `autokeras` github repo.