### PR TITLE
Bump keras autodoc to 0.3.0. Now with aliases!

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -17,49 +17,36 @@ from autokeras.hypermodel import hyperblock
 # [classA, (classB, ['method1', 'method2', ...]), ...]
 # 4) Choose which methods to document (methods listed as qualified names):
 # [classA, (classB, [module.classB.method1, module.classB.method2, ...]), ...]
-PAGES = [
-    {
-        'page': 'auto_model.md',
-        'classes': [
-            (auto_model.AutoModel, [
-                auto_model.AutoModel.fit,
-                auto_model.AutoModel.predict,
-            ]),
-        ]
-    },
-    {
-        'page': 'graph_auto_model.md',
-        'classes': [
-            (auto_model.GraphAutoModel, [
-                auto_model.GraphAutoModel.fit,
-                auto_model.GraphAutoModel.predict,
-            ]),
-        ]
-    },
-    {
-        'page': 'block.md',
-        'classes': [hyperblock.ImageBlock,
-                    hyperblock.TextBlock,
-                    hyperblock.StructuredDataBlock,
-                    block.ResNetBlock,
-                    block.XceptionBlock,
-                    block.ConvBlock,
-                    block.RNNBlock,
-                    block.Merge],
-    },
-    {
-        'page': 'task.md',
-        'classes': [task.ImageClassifier,
-                    task.ImageRegressor,
-                    task.TextClassifier,
-                    task.TextRegressor],
-    },
-    {
-        'page': 'head.md',
-        'classes': [head.ClassificationHead,
-                    head.RegressionHead],
-    }
-]
+PAGES = {
+    'auto_model.md': [
+        auto_model.AutoModel,
+        auto_model.AutoModel.fit,
+        auto_model.AutoModel.predict,
+    ],
+    'graph_auto_model.md': [
+        'autokeras.GraphAutoModel',
+        'autokeras.GraphAutoModel.fit',
+        'autokeras.GraphAutoModel.predict',
+    ],
+    'block.md': [
+         hyperblock.ImageBlock,
+         hyperblock.TextBlock,
+         hyperblock.StructuredDataBlock,
+         block.ResNetBlock,
+         block.XceptionBlock,
+         block.ConvBlock,
+         block.RNNBlock,
+         block.Merge
+     ],
+    'task.md': [
+        task.ImageClassifier,
+        task.ImageRegressor,
+        task.TextClassifier,
+        task.TextRegressor
+    ],
+    'head.md': [head.ClassificationHead, head.RegressionHead]
+}
+
 
 ROOT = 'http://autokeras.com/'
 


### PR DESCRIPTION
This PR bumps keras autodoc to v0.3.0. 

__Notably__:
* The structure of `PAGES` has changed, and is now simpler.
* You can now use aliases. For that use a string instead of the function/class/method. I've added an example with `autokeras.GraphAutoModel` here.

__On a side note about aliases__: 

Keras has a nice alias structure: layers are under `keras.layers` and callbacks are under `keras.callbacks`. Here, everything is under `autokeras` (for example `autokeras.RNNBlock`. What about moving all blocks under `autokeras.blocks` for example? It would help with the autocompletion in IDEs and with the navigation in the codebase.
