### PR TITLE
Bumped the keras-autodoc version to 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
         - pip install git+https://github.com/keras-team/keras-tuner.git@1.0rc0
         - pip install mkdocs
         - pip install mkdocs-material
-        - pip install git+https://github.com/keras-team/keras-autodoc.git@v0.3.0
+        - pip install keras-autodoc==0.4.0
         - sh shell/docs.sh
       deploy:
         - provider: pages


### PR DESCRIPTION
Two new goodies coming with this release:

When the function/class/method signature is too long, it does a nice line break automatically:

```python
autokeras.task.ImageClassifier(num_classes=None, multi_label=False, loss=None, metrics=None, name='image_classifier', max_trials=100, directory=None, objective='val_loss', seed=None)
```

becomes:

```python
autokeras.task.ImageClassifier(
    num_classes=None,
    multi_label=False,
    loss=None,
    metrics=None,
    name="image_classifier",
    max_trials=100,
    directory=None,
    objective="val_loss",
    seed=None,
)
```

Also, the `[Source]` link was displayed before only next to classes. Now it is also displayed next to methods and functions.