### PR TITLE
Download tensorflow-cpu for faster CI.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[tests] --progress-bar off
-        pip install tensorflow
+        pip install tensorflow-cpu
     - name: Lint with flake8
       run: |
         pip install flake8


### PR DESCRIPTION
### Details of the Pull Request

Currently, `pip install tensorflow` installs the GPU version (400 MB), this PR proposes to install tensorflow cpu (100MB) in the CI.

The step "install dependencies" went from 1m 48s to 50s.

The step "Test with pytest" went from 2m57s to 2m34s (this speedup might be unrelated).