### PR TITLE
Fixed: wrong default value for `overwrite` in classes' help.

### DIFF
--- a/autokeras/task.py
+++ b/autokeras/task.py
@@ -30,7 +30,7 @@ class ImageClassifier(SupervisedImagePipeline):
             AutoModel in the current directory.
         objective: String. Name of model metric to minimize
             or maximize, e.g. 'val_accuracy'. Defaults to 'val_loss'.
-        overwrite: Boolean. Defaults to `False`. If `False`, reloads an existing
+        overwrite: Boolean. Defaults to `True`. If `False`, reloads an existing
             project of the same name if one is found. Otherwise, overwrites the
             project.
         seed: Int. Random seed.
@@ -132,7 +132,7 @@ class ImageRegressor(SupervisedImagePipeline):
             AutoModel in the current directory.
         objective: String. Name of model metric to minimize
             or maximize, e.g. 'val_accuracy'. Defaults to 'val_loss'.
-        overwrite: Boolean. Defaults to `False`. If `False`, reloads an existing
+        overwrite: Boolean. Defaults to `True`. If `False`, reloads an existing
             project of the same name if one is found. Otherwise, overwrites the
             project.
         seed: Int. Random seed.
@@ -242,7 +242,7 @@ class TextClassifier(SupervisedTextPipeline):
             AutoModel in the current directory.
         objective: String. Name of model metric to minimize
             or maximize, e.g. 'val_accuracy'. Defaults to 'val_loss'.
-        overwrite: Boolean. Defaults to `False`. If `False`, reloads an existing
+        overwrite: Boolean. Defaults to `True`. If `False`, reloads an existing
             project of the same name if one is found. Otherwise, overwrites the
             project.
         seed: Int. Random seed.
@@ -345,7 +345,7 @@ class TextRegressor(SupervisedTextPipeline):
             AutoModel in the current directory.
         objective: String. Name of model metric to minimize
             or maximize, e.g. 'val_accuracy'. Defaults to 'val_loss'.
-        overwrite: Boolean. Defaults to `False`. If `False`, reloads an existing
+        overwrite: Boolean. Defaults to `True`. If `False`, reloads an existing
             project of the same name if one is found. Otherwise, overwrites the
             project.
         seed: Int. Random seed.
@@ -594,7 +594,7 @@ class StructuredDataClassifier(SupervisedStructuredDataPipeline):
             AutoModel in the current directory.
         objective: String. Name of model metric to minimize
             or maximize. Defaults to 'val_accuracy'.
-        overwrite: Boolean. Defaults to `False`. If `False`, reloads an existing
+        overwrite: Boolean. Defaults to `True`. If `False`, reloads an existing
             project of the same name if one is found. Otherwise, overwrites the
             project.
         seed: Int. Random seed.
@@ -697,7 +697,7 @@ class StructuredDataRegressor(SupervisedStructuredDataPipeline):
             AutoModel in the current directory.
         objective: String. Name of model metric to minimize
             or maximize, e.g. 'val_accuracy'. Defaults to 'val_loss'.
-        overwrite: Boolean. Defaults to `False`. If `False`, reloads an existing
+        overwrite: Boolean. Defaults to `True`. If `False`, reloads an existing
             project of the same name if one is found. Otherwise, overwrites the
             project.
         seed: Int. Random seed.
@@ -766,7 +766,7 @@ class TimeSeriesForecaster(auto_model.AutoModel):
             AutoModel in the current directory.
         objective: String. Name of model metric to minimize
             or maximize, e.g. 'val_accuracy'. Defaults to 'val_loss'.
-        overwrite: Boolean. Defaults to `False`. If `False`, reloads an existing
+        overwrite: Boolean. Defaults to `True`. If `False`, reloads an existing
             project of the same name if one is found. Otherwise, overwrites the
             project.
         seed: Int. Random seed.


### PR DESCRIPTION
The file "autokeras/task.py" had for each of the classes, the `overwrite` parameter set to default as `True`, however, on the help it said that the default value was `False`.
I guess this was wrong, because on the "autokeras/auto_model.py" file, for the `AutoModel` class the `overwrite` parameter is `False` by default.