### PR TITLE
Remove the extra quote mark from the PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://github.com/keras-team/autokeras/workflows/Tests/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/keras-team/autokeras/branch/master/graph/badge.svg)](https://codecov.io/gh/keras-team/autokeras)
-[![PyPI version](https://badge.fury.io/py/autokeras.svg)](https://badge.fury.io/py/autokeras")
+[![PyPI version](https://badge.fury.io/py/autokeras.svg)](https://badge.fury.io/py/autokeras)
 
 Official Website: [autokeras.com](https://autokeras.com)
 


### PR DESCRIPTION
With the quote mark the badge does not take you to the package. Was starting to bug me that I could click through and see the current version that I can pip install.