### PR TITLE
pinning the tf version to avoid bugs.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[tests] --progress-bar off
-        pip install tf-nightly
+        pip install tf-nightly==2.2.0.dev20200208
     - name: Lint
       run: |
         flake8


### PR DESCRIPTION
Having the tensorflow version changing automatically can make the CI fail if a bug is introduced in tensorflow nightly. Pinning the version and bumping it manually with pull requests is safer.