### PR TITLE
Use tmp_path instead of tmp_dir.

### DIFF
--- a/tests/autokeras/auto_model_test.py
+++ b/tests/autokeras/auto_model_test.py
@@ -1,18 +1,12 @@
 from unittest import mock
 
 import numpy as np
-import pytest
 
 import autokeras as ak
 
 
-@pytest.fixture(scope='module')
-def tmp_dir(tmpdir_factory):
-    return tmpdir_factory.mktemp('test_auto_model')
-
-
 @mock.patch('autokeras.auto_model.get_tuner_class')
-def test_evaluate(tuner_fn, tmp_dir):
+def test_evaluate(tuner_fn, tmp_path):
     x_train = np.random.rand(100, 32)
     y_train = np.random.rand(100, 1)
 
@@ -23,7 +17,7 @@ def test_evaluate(tuner_fn, tmp_dir):
 
     auto_model = ak.AutoModel(input_node,
                               output_node,
-                              directory=tmp_dir,
+                              directory=tmp_path,
                               max_trials=1)
     auto_model.fit(x_train, y_train, epochs=1, validation_data=(x_train, y_train))
     auto_model.evaluate(x_train, y_train)
@@ -31,13 +25,13 @@ def test_evaluate(tuner_fn, tmp_dir):
 
 
 @mock.patch('autokeras.auto_model.get_tuner_class')
-def test_auto_model_predict(tuner_fn, tmp_dir):
+def test_auto_model_predict(tuner_fn, tmp_path):
     x_train = np.random.rand(100, 32, 32, 3)
     y_train = np.random.rand(100, 1)
 
     auto_model = ak.AutoModel(ak.ImageInput(),
                               ak.RegressionHead(),
-                              directory=tmp_dir,
+                              directory=tmp_path,
                               max_trials=2)
     auto_model.fit(x_train, y_train, epochs=2, validation_split=0.2)
     auto_model.predict(x_train)
@@ -45,7 +39,7 @@ def test_auto_model_predict(tuner_fn, tmp_dir):
 
 
 @mock.patch('autokeras.auto_model.get_tuner_class')
-def test_final_fit_concat(tuner_fn, tmp_dir):
+def test_final_fit_concat(tuner_fn, tmp_path):
     tuner = tuner_fn.return_value.return_value
 
     x_train = np.random.rand(100, 32, 32, 3)
@@ -53,7 +47,7 @@ def test_final_fit_concat(tuner_fn, tmp_dir):
 
     auto_model = ak.AutoModel(ak.ImageInput(),
                               ak.RegressionHead(),
-                              directory=tmp_dir,
+                              directory=tmp_path,
                               max_trials=2)
     auto_model.fit(x_train, y_train, epochs=2, validation_split=0.2)
     assert auto_model._split_dataset
@@ -61,7 +55,7 @@ def test_final_fit_concat(tuner_fn, tmp_dir):
 
 
 @mock.patch('autokeras.auto_model.get_tuner_class')
-def test_final_fit_not_concat(tuner_fn, tmp_dir):
+def test_final_fit_not_concat(tuner_fn, tmp_path):
     tuner = tuner_fn.return_value.return_value
 
     x_train = np.random.rand(100, 32, 32, 3)
@@ -69,7 +63,7 @@ def test_final_fit_not_concat(tuner_fn, tmp_dir):
 
     auto_model = ak.AutoModel(ak.ImageInput(),
                               ak.RegressionHead(),
-                              directory=tmp_dir,
+                              directory=tmp_path,
                               max_trials=2)
     auto_model.fit(x_train, y_train, epochs=2, validation_data=(x_train, y_train))
     assert not auto_model._split_dataset
@@ -77,7 +71,7 @@ def test_final_fit_not_concat(tuner_fn, tmp_dir):
 
 
 @mock.patch('autokeras.auto_model.get_tuner_class')
-def test_overwrite(tuner_fn, tmp_dir):
+def test_overwrite(tuner_fn, tmp_path):
     tuner_class = tuner_fn.return_value
 
     x_train = np.random.rand(100, 32, 32, 3)
@@ -85,7 +79,7 @@ def test_overwrite(tuner_fn, tmp_dir):
 
     auto_model = ak.AutoModel(ak.ImageInput(),
                               ak.RegressionHead(),
-                              directory=tmp_dir,
+                              directory=tmp_path,
                               max_trials=2,
                               overwrite=False)
     auto_model.fit(x_train, y_train, epochs=2, validation_data=(x_train, y_train))
@@ -93,7 +87,7 @@ def test_overwrite(tuner_fn, tmp_dir):
 
 
 @mock.patch('autokeras.auto_model.get_tuner_class')
-def test_export_model(tuner_fn, tmp_dir):
+def test_export_model(tuner_fn, tmp_path):
     tuner_class = tuner_fn.return_value
     tuner = tuner_class.return_value
 
@@ -102,7 +96,7 @@ def test_export_model(tuner_fn, tmp_dir):
 
     auto_model = ak.AutoModel(ak.ImageInput(),
                               ak.RegressionHead(),
-                              directory=tmp_dir,
+                              directory=tmp_path,
                               max_trials=2,
                               overwrite=False)
     auto_model.fit(x_train, y_train, epochs=2, validation_data=(x_train, y_train))

--- a/tests/autokeras/engine/tuner_test.py
+++ b/tests/autokeras/engine/tuner_test.py
@@ -1,27 +1,21 @@
 from unittest import mock
 
 import kerastuner
-import pytest
 import tensorflow as tf
 
 from autokeras.engine import tuner as tuner_module
 from tests import utils
 
 
-@pytest.fixture(scope='module')
-def tmp_dir(tmpdir_factory):
-    return tmpdir_factory.mktemp('test_auto_model')
-
-
 @mock.patch('kerastuner.engine.base_tuner.BaseTuner.__init__')
 @mock.patch('kerastuner.engine.base_tuner.BaseTuner.search')
 @mock.patch('tensorflow.keras.Model.fit')
-def test_add_early_stopping(fit_fn, base_tuner_search, init, tmp_dir):
+def test_add_early_stopping(fit_fn, base_tuner_search, init, tmp_path):
     graph = utils.build_graph()
     tuner = tuner_module.AutoTuner(oracle=mock.Mock(), hypermodel=graph)
     tuner.hypermodel = graph
     tuner.oracle = mock.Mock()
-    tuner.directory = tmp_dir
+    tuner.directory = tmp_path
     tuner.project_name = ''
     hp = kerastuner.HyperParameters()
     trial = mock.Mock()
@@ -38,11 +32,11 @@ def test_add_early_stopping(fit_fn, base_tuner_search, init, tmp_dir):
 
 
 @mock.patch('kerastuner.engine.base_tuner.BaseTuner.__init__')
-def test_overwrite_init(base_tuner_init, tmp_dir):
+def test_overwrite_init(base_tuner_init, tmp_path):
     tuner_module.AutoTuner(
         oracle=mock.Mock(),
         hypermodel=lambda hp: None,
-        directory=tmp_dir)
+        directory=tmp_path)
 
     assert not base_tuner_init.call_args_list[0][1]['overwrite']
 
@@ -50,12 +44,12 @@ def test_overwrite_init(base_tuner_init, tmp_dir):
 @mock.patch('kerastuner.engine.base_tuner.BaseTuner.__init__')
 @mock.patch('kerastuner.engine.base_tuner.BaseTuner.search')
 @mock.patch('tensorflow.keras.Model.fit')
-def test_overwrite_search(fit_fn, base_tuner_search, init, tmp_dir):
+def test_overwrite_search(fit_fn, base_tuner_search, init, tmp_path):
     graph = utils.build_graph()
     tuner = tuner_module.AutoTuner(oracle=mock.Mock(), hypermodel=graph)
     tuner.hypermodel = graph
     tuner.oracle = mock.Mock()
-    tuner.directory = tmp_dir
+    tuner.directory = tmp_path
     tuner.project_name = ''
     hp = kerastuner.HyperParameters()
     trial = mock.Mock()

--- a/tests/autokeras/graph_test.py
+++ b/tests/autokeras/graph_test.py
@@ -6,11 +6,6 @@ import autokeras as ak
 from autokeras import graph as graph_module
 
 
-@pytest.fixture(scope='module')
-def tmp_dir(tmpdir_factory):
-    return tmpdir_factory.mktemp('test_graph')
-
-
 def test_set_hp():
     input_node = ak.Input((32,))
     output_node = input_node
@@ -92,7 +87,7 @@ def test_graph_basics():
     assert model.output_shape == (None, 1)
 
 
-def test_graph_save_load(tmp_dir):
+def test_graph_save_load(tmp_path):
     input1 = ak.Input()
     input2 = ak.Input()
     output1 = ak.DenseBlock()(input1)

--- a/tests/autokeras/tasks/image_test.py
+++ b/tests/autokeras/tasks/image_test.py
@@ -1,23 +1,16 @@
 from unittest import mock
 
-import pytest
-
 from autokeras.tasks import image
 from tests import utils
 
 
-@pytest.fixture(scope='module')
-def tmp_dir(tmpdir_factory):
-    return tmpdir_factory.mktemp('test_image')
-
-
 @mock.patch('autokeras.auto_model.AutoModel.__init__')
-def test_image_classifier(auto_model):
-    image.ImageClassifier(directory=tmp_dir, max_trials=2, seed=utils.SEED)
+def test_image_classifier(auto_model, tmp_path):
+    image.ImageClassifier(directory=tmp_path, max_trials=2, seed=utils.SEED)
     assert auto_model.called
 
 
 @mock.patch('autokeras.auto_model.AutoModel.__init__')
-def test_image_regressor(auto_model):
-    image.ImageRegressor(directory=tmp_dir, max_trials=2, seed=utils.SEED)
+def test_image_regressor(auto_model, tmp_path):
+    image.ImageRegressor(directory=tmp_path, max_trials=2, seed=utils.SEED)
     assert auto_model.called

--- a/tests/autokeras/tasks/structure_data_test.py
+++ b/tests/autokeras/tasks/structure_data_test.py
@@ -8,27 +8,22 @@ from autokeras.tasks import structured_data
 from tests import utils
 
 
-@pytest.fixture(scope='module')
-def tmp_dir(tmpdir_factory):
-    return tmpdir_factory.mktemp('test_structured_data')
-
-
-def test_structured_data_unknown_str_in_col_type(tmp_dir):
+def test_structured_data_unknown_str_in_col_type(tmp_path):
     with pytest.raises(ValueError) as info:
         structured_data.StructuredDataClassifier(
             column_types=utils.FALSE_COLUMN_TYPES_FROM_CSV,
-            directory=tmp_dir,
+            directory=tmp_path,
             max_trials=1,
             seed=utils.SEED)
     assert 'Column_types should be either "categorical"' in str(info.value)
 
 
-def test_structured_data_col_name_type_mismatch(tmp_dir):
+def test_structured_data_col_name_type_mismatch(tmp_path):
     with pytest.raises(ValueError) as info:
         structured_data.StructuredDataClassifier(
             column_names=utils.COLUMN_NAMES_FROM_NUMPY,
             column_types=utils.COLUMN_TYPES_FROM_CSV,
-            directory=tmp_dir,
+            directory=tmp_path,
             max_trials=1,
             seed=utils.SEED)
     assert 'Column_names and column_types are mismatched.' in str(info.value)
@@ -36,14 +31,14 @@ def test_structured_data_col_name_type_mismatch(tmp_dir):
 
 @mock.patch('autokeras.auto_model.AutoModel.fit')
 @mock.patch('autokeras.auto_model.AutoModel.__init__')
-def test_structured_classifier(init, fit, tmp_dir):
+def test_structured_classifier(init, fit, tmp_path):
     num_data = 500
     train_x = utils.generate_structured_data(num_data)
     train_y = utils.generate_one_hot_labels(num_instances=num_data, num_classes=3)
 
     clf = structured_data.StructuredDataClassifier(
         column_names=utils.COLUMN_NAMES_FROM_NUMPY,
-        directory=tmp_dir,
+        directory=tmp_path,
         max_trials=1,
         seed=utils.SEED)
     clf.fit(train_x, train_y, epochs=2, validation_data=(train_x, train_y))
@@ -54,14 +49,14 @@ def test_structured_classifier(init, fit, tmp_dir):
 
 @mock.patch('autokeras.auto_model.AutoModel.fit')
 @mock.patch('autokeras.auto_model.AutoModel.__init__')
-def test_structured_regressor(init, fit, tmp_dir):
+def test_structured_regressor(init, fit, tmp_path):
     num_data = 500
     train_x = utils.generate_structured_data(num_data)
     train_y = utils.generate_data(num_instances=100, shape=(1,))
 
     clf = structured_data.StructuredDataRegressor(
         column_names=utils.COLUMN_NAMES_FROM_NUMPY,
-        directory=tmp_dir,
+        directory=tmp_path,
         max_trials=1,
         seed=utils.SEED)
     clf.fit(train_x, train_y, epochs=2, validation_data=(train_x, train_y))
@@ -72,9 +67,9 @@ def test_structured_regressor(init, fit, tmp_dir):
 
 @mock.patch('autokeras.auto_model.AutoModel.fit')
 @mock.patch('autokeras.auto_model.AutoModel.__init__')
-def test_structured_data_classifier_from_csv(init, fit, tmp_dir):
+def test_structured_data_classifier_from_csv(init, fit, tmp_path):
     clf = structured_data.StructuredDataClassifier(
-        directory=tmp_dir,
+        directory=tmp_path,
         max_trials=1,
         seed=utils.SEED)
 

--- a/tests/autokeras/tasks/text_test.py
+++ b/tests/autokeras/tasks/text_test.py
@@ -1,23 +1,16 @@
 from unittest import mock
 
-import pytest
-
 from autokeras.tasks import text
 from tests import utils
 
 
-@pytest.fixture(scope='module')
-def tmp_dir(tmpdir_factory):
-    return tmpdir_factory.mktemp('test_text')
-
-
 @mock.patch('autokeras.auto_model.AutoModel.__init__')
-def test_text_classifier(auto_model, tmp_dir):
-    text.TextClassifier(directory=tmp_dir, max_trials=2, seed=utils.SEED)
+def test_text_classifier(auto_model, tmp_path):
+    text.TextClassifier(directory=tmp_path, max_trials=2, seed=utils.SEED)
     assert auto_model.called
 
 
 @mock.patch('autokeras.auto_model.AutoModel.__init__')
-def test_text_regressor(auto_model, tmp_dir):
-    text.TextRegressor(directory=tmp_dir, max_trials=2, seed=utils.SEED)
+def test_text_regressor(auto_model, tmp_path):
+    text.TextRegressor(directory=tmp_path, max_trials=2, seed=utils.SEED)
     assert auto_model.called

--- a/tests/integration_tests/functional_api_test.py
+++ b/tests/integration_tests/functional_api_test.py
@@ -1,16 +1,10 @@
-import pytest
 from tensorflow.python.keras.datasets import mnist
 
 import autokeras as ak
 from tests import utils
 
 
-@pytest.fixture(scope='module')
-def tmp_dir(tmpdir_factory):
-    return tmpdir_factory.mktemp('test_functional_api')
-
-
-def test_functional_api(tmp_dir):
+def test_functional_api(tmp_path):
     # Prepare the data.
     num_instances = 20
     (image_x, train_y), (test_x, test_y) = mnist.load_data()
@@ -62,7 +56,7 @@ def test_functional_api(tmp_dir):
             text_input,
             structured_data_input
         ],
-        directory=tmp_dir,
+        directory=tmp_path,
         outputs=[
             regression_outputs,
             classification_outputs

--- a/tests/integration_tests/io_api_test.py
+++ b/tests/integration_tests/io_api_test.py
@@ -1,16 +1,10 @@
-import pytest
 from tensorflow.python.keras.datasets import mnist
 
 import autokeras as ak
 from tests import utils
 
 
-@pytest.fixture(scope='module')
-def tmp_dir(tmpdir_factory):
-    return tmpdir_factory.mktemp('test_io_api')
-
-
-def test_io_api(tmp_dir):
+def test_io_api(tmp_path):
     (image_x, train_y), (test_x, test_y) = mnist.load_data()
     (text_x, train_y), (test_x, test_y) = utils.imdb_raw()
 
@@ -32,7 +26,7 @@ def test_io_api(tmp_dir):
         outputs=[ak.RegressionHead(metrics=['mae']),
                  ak.ClassificationHead(loss='categorical_crossentropy',
                                        metrics=['accuracy'])],
-        directory=tmp_dir,
+        directory=tmp_path,
         max_trials=2,
         seed=utils.SEED)
     automodel.fit([

--- a/tests/integration_tests/task_api_test.py
+++ b/tests/integration_tests/task_api_test.py
@@ -1,19 +1,13 @@
-import pytest
 import tensorflow as tf
 
 import autokeras as ak
 from tests import utils
 
 
-@pytest.fixture(scope='module')
-def tmp_dir(tmpdir_factory):
-    return tmpdir_factory.mktemp('task_api')
-
-
-def test_image_classifier(tmp_dir):
+def test_image_classifier(tmp_path):
     train_x = utils.generate_data(num_instances=100, shape=(32, 32, 3))
     train_y = utils.generate_one_hot_labels(num_instances=100, num_classes=10)
-    clf = ak.ImageClassifier(directory=tmp_dir, max_trials=2, seed=utils.SEED)
+    clf = ak.ImageClassifier(directory=tmp_path, max_trials=2, seed=utils.SEED)
     clf.fit(train_x, train_y, epochs=1, validation_split=0.2)
     keras_model = clf.export_model()
     clf.evaluate(train_x, train_y)
@@ -21,41 +15,41 @@ def test_image_classifier(tmp_dir):
     assert isinstance(keras_model, tf.keras.Model)
 
 
-def test_image_regressor(tmp_dir):
+def test_image_regressor(tmp_path):
     train_x = utils.generate_data(num_instances=100, shape=(32, 32, 3))
     train_y = utils.generate_data(num_instances=100, shape=(1,))
-    clf = ak.ImageRegressor(directory=tmp_dir, max_trials=2, seed=utils.SEED)
+    clf = ak.ImageRegressor(directory=tmp_path, max_trials=2, seed=utils.SEED)
     clf.fit(train_x, train_y, epochs=1, validation_split=0.2)
     clf.export_model()
     assert clf.predict(train_x).shape == (len(train_x), 1)
 
 
-def test_text_classifier(tmp_dir):
+def test_text_classifier(tmp_path):
     (train_x, train_y), (test_x, test_y) = utils.imdb_raw()
-    clf = ak.TextClassifier(directory=tmp_dir, max_trials=2, seed=utils.SEED)
+    clf = ak.TextClassifier(directory=tmp_path, max_trials=2, seed=utils.SEED)
     clf.fit(train_x, train_y, epochs=1, validation_data=(test_x, test_y))
     clf.export_model()
     assert clf.predict(test_x).shape == (len(test_x), 1)
 
 
-def test_text_regressor(tmp_dir):
+def test_text_regressor(tmp_path):
     (train_x, train_y), (test_x, test_y) = utils.imdb_raw()
     train_y = utils.generate_data(num_instances=train_y.shape[0], shape=(1,))
     test_y = utils.generate_data(num_instances=test_y.shape[0], shape=(1,))
-    clf = ak.TextRegressor(directory=tmp_dir, max_trials=2, seed=utils.SEED)
+    clf = ak.TextRegressor(directory=tmp_path, max_trials=2, seed=utils.SEED)
     clf.fit(train_x, train_y, epochs=1, validation_data=(test_x, test_y))
     clf.export_model()
     assert clf.predict(test_x).shape == (len(test_x), 1)
 
 
-def test_structured_data_from_numpy_regressor(tmp_dir):
+def test_structured_data_from_numpy_regressor(tmp_path):
     num_data = 500
     num_train = 400
     data = utils.generate_data(num_data, shape=(10,))
     x_train, x_test = data[:num_train], data[num_train:]
     y = utils.generate_data(num_instances=num_data, shape=(1,))
     y_train, y_test = y[:num_train], y[num_train:]
-    clf = ak.StructuredDataRegressor(directory=tmp_dir,
+    clf = ak.StructuredDataRegressor(directory=tmp_path,
                                      max_trials=2,
                                      seed=utils.SEED)
     clf.fit(x_train, y_train, epochs=20, validation_data=(x_train, y_train))
@@ -63,14 +57,14 @@ def test_structured_data_from_numpy_regressor(tmp_dir):
     assert clf.predict(x_test).shape == (len(y_test), 1)
 
 
-def test_structured_data_from_numpy_classifier(tmp_dir):
+def test_structured_data_from_numpy_classifier(tmp_path):
     num_data = 500
     num_train = 400
     data = utils.generate_structured_data(num_data)
     x_train, x_test = data[:num_train], data[num_train:]
     y = utils.generate_one_hot_labels(num_instances=num_data, num_classes=3)
     y_train, y_test = y[:num_train], y[num_train:]
-    clf = ak.StructuredDataClassifier(directory=tmp_dir,
+    clf = ak.StructuredDataClassifier(directory=tmp_path,
                                       max_trials=1,
                                       seed=utils.SEED)
     clf.fit(x_train, y_train, epochs=2, validation_data=(x_train, y_train))


### PR DESCRIPTION
This is needed for #957. I wanted to do a separate PR to avoid making it difficult to review.

`tmp_path` creates a temporary directory and return a pathlib object, as opposed to the `tmp_dir` made by hand returning a `py._path` which is deprecated. See https://github.com/pytest-dev/pytest/issues/3985 .

Having `py._path` objects doesn't make the type checker very happy :p