### PR TITLE
Fix input not TTY for pre-commit

### DIFF
--- a/shell/pre-commit.sh
+++ b/shell/pre-commit.sh
@@ -4,4 +4,4 @@ set -e
 
 export DOCKER_BUILDKIT=1
 docker build -t autokeras_formatting -f docker/pre-commit.Dockerfile .
-docker run --rm -it -v "$(pwd -P):/autokeras" autokeras_formatting
+docker run --rm -t -v "$(pwd -P):/autokeras" autokeras_formatting


### PR DESCRIPTION
It seems to cause an error when running the commit hook. We don't need `-i` anyway since it's not supposed to be interactive. 