### PR TITLE
Typing the XceptionBlock.

### DIFF
--- a/autokeras/hypermodels/basic.py
+++ b/autokeras/hypermodels/basic.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from kerastuner.applications import resnet
 from kerastuner.applications import xception
 from tensorflow.keras import layers
@@ -307,10 +309,10 @@ class XceptionBlock(block_module.Block, xception.HyperXception):
     """
 
     def __init__(self,
-                 activation=None,
-                 initial_strides=None,
-                 num_residual_blocks=None,
-                 pooling=None,
+                 activation: Optional[str] = None,
+                 initial_strides: Optional[int] = None,
+                 num_residual_blocks: Optional[int] = None,
+                 pooling: Optional[str] = None,
                  **kwargs):
         super().__init__(include_top=False, input_shape=(10,), **kwargs)
         self.activation = activation

--- a/autokeras/hypermodels/basic.py
+++ b/autokeras/hypermodels/basic.py
@@ -4,6 +4,7 @@ from kerastuner.applications import resnet
 from kerastuner.applications import xception
 from tensorflow.keras import layers
 from tensorflow.python.util import nest
+from typing_extensions import Literal
 
 from autokeras import utils
 from autokeras.engine import block as block_module
@@ -304,15 +305,15 @@ class XceptionBlock(block_module.Block, xception.HyperXception):
         initial_strides: Int. If left unspecified, it will be tuned automatically.
         num_residual_blocks: Int. If left unspecified, it will be tuned
             automatically.
-        pooling: String. 'ave', 'flatten', or 'max'. If left unspecified, it will be
+        pooling: String. 'avg', 'flatten', or 'max'. If left unspecified, it will be
             tuned automatically.
     """
 
     def __init__(self,
-                 activation: Optional[str] = None,
+                 activation: Literal['selu', 'relu', None] = None,
                  initial_strides: Optional[int] = None,
                  num_residual_blocks: Optional[int] = None,
-                 pooling: Optional[str] = None,
+                 pooling: Literal['avg', 'flatten', 'max', None] = None,
                  **kwargs):
         super().__init__(include_top=False, input_shape=(10,), **kwargs)
         self.activation = activation

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'scikit-learn',
         'numpy',
         'pandas',
-        'typing_extensions'
+        'typing-extensions'
     ],
     extras_require={
         'tests': ['pytest>=4.4.0',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'scikit-learn',
         'numpy',
         'pandas',
+        'typing_extensions'
     ],
     extras_require={
         'tests': ['pytest>=4.4.0',

--- a/tests/autokeras/typed_api_test.py
+++ b/tests/autokeras/typed_api_test.py
@@ -33,7 +33,6 @@ EXCEPTION_LIST = [
     autokeras.TextBlock,
     autokeras.TextToIntSequence,
     autokeras.TextToNgramVector,
-    autokeras.XceptionBlock,
     autokeras.ImageInput,
     autokeras.Input,
     autokeras.StructuredDataInput,


### PR DESCRIPTION
Related to #949

A bit of background on this, `Literal` is quite useful for IDEs/type checkers to be able to identify arguments which can only take specific values. It works with `str`, `int`, `None` and `bool`. See here: https://docs.python.org/3/library/typing.html#typing.Literal 

But the problem is that it's available only for py3.8+. 

A backport was made, this is what we're using right now. See the section in the PEP: https://www.python.org/dev/peps/pep-0586/#backporting-the-literal-type