### PR TITLE
Clarifying the supported python versions.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         pip install git+https://github.com/gabrieldemarmiesse/typed_api.git@0.1.1
         pip install -e .[tests] --progress-bar off
         pip install tensorflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.6
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.6
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         pip install git+https://github.com/gabrieldemarmiesse/typed_api.git@0.1.1
         pip install -e .[tests] --progress-bar off
         pip install tf-nightly==2.2.0.dev20200208

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip3 install autokeras
 
 Please follow the [installation guide](https://autokeras.com/install) for more details.
 
-**Note:** Currently, AutoKeras is only compatible with **Python >= 3.6** and **TensorFlow >= 2.1.0**.
+**Note:** Currently, AutoKeras is only compatible with **Python >= 3.5** and **TensorFlow >= 2.1.0**.
 
 ## Community
 <a href="https://keras-slack-autojoin.herokuapp.com/"><img src="https://github.com/keras-team/autokeras/blob/master/docs/templates/img/slack.png?raw=true" alt="drawing" width="150"/></a>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip3 install autokeras
 
 Please follow the [installation guide](https://autokeras.com/install) for more details.
 
-**Note:** Currently, AutoKeras is only compatible with **Python 3** and **TensorFlow >= 2.1.0**.
+**Note:** Currently, AutoKeras is only compatible with **Python >= 3.6** and **TensorFlow >= 2.1.0**.
 
 ## Community
 <a href="https://keras-slack-autojoin.herokuapp.com/"><img src="https://github.com/keras-team/autokeras/blob/master/docs/templates/img/slack.png?raw=true" alt="drawing" width="150"/></a>

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Intended Audience :: Education",
         "Intended Audience :: Science/Research",
         'License :: OSI Approved :: MIT License',
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: Mathematics",

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,17 @@ setup(
                   'typeguard>=2,<3'
                   ],
     },
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
+        'License :: OSI Approved :: MIT License',
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Scientific/Engineering :: Mathematics",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Software Development :: Libraries",
+    ],
+    license="MIT",
     packages=find_packages(exclude=('tests',)),
 )


### PR DESCRIPTION
The list of supported python versions wasn't very clear. I think we're compatible with python 3.6+, as such, we should test with the oldest version we support since python has strong backward compatibility guarantees.

The classifiers appear on pypi to make the search easier.