### PR TITLE
Building the docs in the tests and splitted the pre-commit check.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,6 @@ jobs:
         python -m pip install --upgrade pip setuptools
         pip install -e .[tests] --progress-bar off
         pip install tf-nightly
-    - name: Lint
-      run: |
-        flake8
-        isort -sl -rc -c
     - name: Test with pytest
       run: |
         pytest --cov=autokeras --cov-report xml:coverage.xml
@@ -32,6 +28,13 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }} #required
         file: ./coverage.xml #optional
+  formatting:
+    name: Check the code format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run pre-commit
+        run: bash shell/pre-commit.sh
   build-docs:
     name: Build the docs
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,3 +32,23 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }} #required
         file: ./coverage.xml #optional
+  build-docs:
+    name: Build the docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install -e .
+          pip install tf-nightly
+          pip install -r docs/requirements.txt
+      - name: Build the docs
+        run: |
+          cd docs
+          python autogen.py
+          mkdocs generate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,4 @@ jobs:
         run: |
           cd docs
           python autogen.py
-          mkdocs generate
+          mkdocs build


### PR DESCRIPTION
Fix part of #994

For faster feedback, I believe it's better to check that the pre-commit has run in a separate job. It runs in 40 seconds only.