### PR TITLE
Examples for Image and Text Regression [resolves #1061]

### DIFF
--- a/docs/templates/tutorial/image_regression.md
+++ b/docs/templates/tutorial/image_regression.md
@@ -1,2 +1,58 @@
-We are still working on this tutorial.
-Thank you for your patience!
+# Image Regression
+## Celebrity Ages Example
+
+Regression tasks estimate a numeric variable, such as the price of a house
+or voter turnout.
+
+This example is adapted from
+[a notebook](https://gist.github.com/mapmeld/98d1e9839f2d1f9c4ee197953661ed07)
+which estimates a person's age from their image, trained on the
+[IMDB-WIKI](https://data.vision.ee.ethz.ch/cvl/rrothe/imdb-wiki/)
+photographs of famous people.
+
+First, prepare your image data in a ```numpy.ndarray``` or ```tensorflow.Dataset```
+format. Each image must have the same shape, meaning
+each has the same width, height, and color channels as other images in the set.
+
+```python
+import pandas as pd
+import numpy as np
+from PIL import Image
+
+# converting from other formats (such as pandas) to numpy
+age_outputs = train_df.age.to_numpy(dtype="int")
+
+# convert file paths into consistent images
+images = []
+for img_path in train_df.img_path:
+  images.append(
+    np.asarray(
+      Image.open(img_path)
+        .resize((256, 128)) # same dimensions on every image
+        .convert('L') # grayscale (original data had mix of RGB and grayscale)
+    )
+  )
+image_inputs = np.array(images)
+```
+
+Next, initialize and train the [ImageRegressor](/image_regressor).
+
+```python
+import autokeras as ak
+
+# Initialize the image regressor
+reg = ak.ImageRegressor(max_trials=15) # AutoKeras tries 15 different models.
+
+# Find the best model for the given training data
+reg.fit(image_inputs, age_outputs)
+
+# Predict with the chosen model:
+predict_y = reg.predict(predict_x)
+```
+
+Measure the accuracy of the regressor on an independent test set:
+
+```python
+# Evaluate the chosen model with testing data
+print(reg.evaluate(test_images, test_ages))
+```

--- a/docs/templates/tutorial/text_regression.md
+++ b/docs/templates/tutorial/text_regression.md
@@ -1,3 +1,64 @@
-We are still working on this tutorial.
-Thank you for your patience!
+# Text Regression
+## Social Media Articles Example
 
+Regression tasks estimate a numeric variable, such as the price of a house
+or a person's age.
+
+This example estimates the view counts for an article on social media platforms,
+trained on a
+[News Popularity](https://archive.ics.uci.edu/ml/datasets/News+Popularity+in+Multiple+Social+Media+Platforms)
+dataset collected from 2015-2016.
+
+First, prepare your text data in a ```numpy.ndarray``` or ```tensorflow.Dataset```
+format.
+
+```python
+import pandas as pd
+import numpy as np
+
+# converting from other formats (such as pandas) to numpy
+train_df = pd.read_csv("./News_Final.csv")
+
+text_inputs = df.Title.to_numpy(dtype="str")
+media_success_outputs = df.Facebook.to_numpy(dtype="int")
+```
+
+Next, initialize and train the [TextRegressor](/text_regressor).
+
+```python
+import autokeras as ak
+
+# Initialize the text regressor
+reg = ak.TextRegressor(max_trials=15) # AutoKeras tries 15 different models.
+
+# Find the best model for the given training data
+reg.fit(text_inputs, media_success_outputs)
+
+# Predict with the chosen model:
+predict_y = reg.predict(predict_x)
+```
+
+If your text source has a larger vocabulary (number of distinct words), you may
+need to create a custom pipeline in AutoKeras to increase the ```max_tokens```
+parameter.
+
+```python
+text_input = (df.Title + " " + df.Headline).to_numpy(dtype="str")
+
+# text input and tokenization
+input_node = ak.TextInput()
+output_node = ak.TextToIntSequence(max_tokens=20000)(input_node)
+
+# regression output
+output_node = ak.RegressionHead()(output_node)
+
+# initialize AutoKeras and find the best model
+reg = ak.AutoModel(inputs=input_node, outputs=output_node, max_trials=15)
+reg.fit(text_input, media_success_output)
+```
+
+Measure the accuracy of the regressor on an independent test set:
+
+```python
+print(reg.evaluate(test_text, test_responses))
+```


### PR DESCRIPTION
resolves #1061 by adding missing tutorials in the "Getting Started" pages

- this Text Regression tutorial estimates the popularity of a social media post ( dataset: https://archive.ics.uci.edu/ml/datasets/News+Popularity+in+Multiple+Social+Media+Platforms ). I included samples of exporting a DataFrame to Numpy, and an AutoModel example for projects where you need to increase ```max_tokens```

- this Image Regression tutorial estimates the age of celebrities ( dataset: https://data.vision.ee.ethz.ch/cvl/rrothe/imdb-wiki/ ).  I included samples of loading images into Numpy from their paths in a DataFrame.

On Image Regression, I included a link to a notebook on GitHub because the original dataset is not so straightforward (the metadata is a MATLAB .mat file). If you'd rather host this somewhere else or not mention it, let me know