### PR TITLE
Bump keras-autodoc and used aliases for types.

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -94,6 +94,14 @@ PAGES = {
 }
 
 
+aliases_needed = [
+    'tensorflow.keras.callbacks.Callback',
+    'tensorflow.keras.losses.Loss',
+    'tensorflow.keras.metrics.Metric',
+    'tensorflow.data.Dataset'
+]
+
+
 ROOT = 'http://autokeras.com/'
 
 autokeras_dir = pathlib.Path(__file__).resolve().parents[1]
@@ -113,6 +121,7 @@ def generate(dest_dir):
         'https://github.com/keras-team/autokeras/blob/master',
         template_dir,
         autokeras_dir / 'examples',
+        extra_aliases=aliases_needed,
     )
     doc_generator.generate(dest_dir)
     readme = (autokeras_dir / 'README.md').read_text()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-keras-autodoc==0.4.1
+keras-autodoc==0.5.0
 mkdocs
 mkdocs-material
 pygments


### PR DESCRIPTION
![website](https://user-images.githubusercontent.com/12891691/81946447-a6736180-95ff-11ea-955f-3218f8fc9391.png)
### Details of the Pull Request

This pull request bumps keras-autodoc to the latest version. This latest version adds the type hints in the description for better readability. Screenshot coming. It's also possible now to control the lenght of the lines for black when formatting the signatures. I don't know if we need that.

To display nicely the types that are not in the autokeras, it's needed to provide aliases. Keras-autodoc resolves them automatically from a single string.