### PR TITLE
setup.py: Move tensorflow to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     keywords=['AutoML', 'Keras'],
     install_requires=[
         'packaging',
-        'tensorflow>=2.2.0',
         'scikit-learn',
         'numpy',
         'pandas',
@@ -35,6 +34,8 @@ setup(
                   'typeguard>=2,<2.10.0',
                   'typedapi>=0.2,<0.3'
                   ],
+        'tf': ['tensorflow>=2.2.0'],
+        'tf_gpu': ['tensorflow-gpu>=2.2.0'],
     },
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
Move tensorflow requirement to extras_require so that autokeras can be installed if tensorflow-gpu is installed (as in tensorflow/tensorflow:latest-gpu).
Following the practice mentioned in https://github.com/tensorflow/tensorflow/issues/7166

TODO: Update other docs & Dockerfile
Created pull request to discuss the approach.

Docs will have to be updated to reflect autokeras[tf] & autokeras[tf_gpu]
I think 2 different docker images should be available - one for gpu & one without