### PR TITLE
docker: install local autokeras + update tensorflow and keras-tuner version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
-FROM tensorflow/tensorflow:2.2.0
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git
-RUN pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc0
-RUN pip install autokeras
+FROM tensorflow/tensorflow:2.3.0
+RUN python -m pip install --no-cache-dir https://github.com/keras-team/keras-tuner/tarball/1.0.2rc1
+WORKDIR /opt/autokeras
+COPY . .
+RUN python -m pip install --no-cache-dir --editable .
+WORKDIR /work


### PR DESCRIPTION
### Details of the Pull Request

This PR halves the size of the autokeras Docker image. TensorFlow is updated to 2.3.0, and keras-tuner is updated to 1.0.2rc1. In addition, the local copy of autokeras is used. This is helpful if changes are made to autokeras and a developer would like to test the changes in a Docker image, building the Docker image will use the local copy of the code. Last, the cache is not used in `pip install` to reduce the size of the built image.
