### PR TITLE
Fix multi label encoder bug

### DIFF
--- a/autokeras/preprocessors/encoders.py
+++ b/autokeras/preprocessors/encoders.py
@@ -124,6 +124,7 @@ class MultiLabelEncoder(Encoder):
     """Encoder for multi-label data."""
 
     def __init__(self, **kwargs):
+        kwargs.pop('labels', None)
         super().__init__(labels=[], **kwargs)
 
     def transform(self, dataset):

--- a/autokeras/preprocessors/encoders.py
+++ b/autokeras/preprocessors/encoders.py
@@ -124,7 +124,7 @@ class MultiLabelEncoder(Encoder):
     """Encoder for multi-label data."""
 
     def __init__(self, **kwargs):
-        kwargs.pop('labels', None)
+        kwargs.pop("labels", None)
         super().__init__(labels=[], **kwargs)
 
     def transform(self, dataset):


### PR DESCRIPTION
### Which issue(s) does this Pull Request fix?
resolves #1363 

### Details of the Pull Request
Due to the serialization of the MultiLabelEncoder, the config contains the parameter `labels: []` which is also set in the init method, so that the parameter appears twice. This fix resolves that by removing the `labels` key ouf of the `kwargs` for the `MultiLabelEncoder`