### PR TITLE
Add links to tf.keras.Model.fit for keras.Model.fit references in documentation

### DIFF
--- a/autokeras/auto_model.py
+++ b/autokeras/auto_model.py
@@ -241,7 +241,7 @@ class AutoModel(object):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         # Check validation information.
         if not validation_data and not validation_split:

--- a/autokeras/tasks/image.py
+++ b/autokeras/tasks/image.py
@@ -149,7 +149,7 @@ class ImageClassifier(SupervisedImagePipeline):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         super().fit(
             x=x,
@@ -271,7 +271,7 @@ class ImageRegressor(SupervisedImagePipeline):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         super().fit(
             x=x,
@@ -394,7 +394,7 @@ class ImageSegmenter(SupervisedImagePipeline):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         super().fit(
             x=x,

--- a/autokeras/tasks/structured_data.py
+++ b/autokeras/tasks/structured_data.py
@@ -116,7 +116,7 @@ class BaseStructuredDataPipeline(auto_model.AutoModel):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         # x is file path of training data
         if isinstance(x, str):
@@ -304,7 +304,7 @@ class StructuredDataClassifier(SupervisedStructuredDataPipeline):
                 at the end of each epoch. The model will not be trained on this data.
                 `validation_data` will override `validation_split`. The type of the
                 validation data should be the same as the training data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         super().fit(
             x=x,

--- a/autokeras/tasks/text.py
+++ b/autokeras/tasks/text.py
@@ -144,7 +144,7 @@ class TextClassifier(SupervisedTextPipeline):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         super().fit(
             x=x,
@@ -265,7 +265,7 @@ class TextRegressor(SupervisedTextPipeline):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         super().fit(
             x=x,

--- a/autokeras/tasks/time_series_forecaster.py
+++ b/autokeras/tasks/time_series_forecaster.py
@@ -252,7 +252,7 @@ class TimeseriesForecaster(SupervisedTimeseriesDataPipeline):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         super().fit(
             x=x,
@@ -310,7 +310,7 @@ class TimeseriesForecaster(SupervisedTimeseriesDataPipeline):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         self.fit(
             x=x,
@@ -420,7 +420,7 @@ class TimeseriesClassifier(SupervisedTimeseriesDataPipeline):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         raise NotImplementedError
 
@@ -475,6 +475,6 @@ class TimeseriesClassifier(SupervisedTimeseriesDataPipeline):
                 validation data should be the same as the training data.
                 The best model found would be fit on the training dataset without the
                 validation data.
-            **kwargs: Any arguments supported by keras.Model.fit.
+            **kwargs: Any arguments supported by [keras.Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
         """
         raise NotImplementedError


### PR DESCRIPTION

### Which issue(s) does this Pull Request fix?

N/A

### Details of the Pull Request

This pull request proposes changes to improve the documentation, by adding a link to https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit in the documentation for when `keras.Model.fit` is mentioned.

It could be expanded to add other links for Keras classes/methods, but wanted to get a general feel for if the maintainers would be open to changes like this.

Here is a preview of how the documentation would look:

<img width="866" alt="Screen Shot 2020-10-22 at 5 09 18 PM" src="https://user-images.githubusercontent.com/1163840/96930259-699e7700-1489-11eb-9111-2cbe595118b6.png">


<!-- STEP 4: If the pull request is in progress, click the down green arrow to select "Create Draft Pull Request", and click the button. If the pull request is ready to be reviewed, click "Create Pull Request" button directly. -->
