### PR TITLE
Fix example in BertBlock comment to change import and parameter naming

### DIFF
--- a/autokeras/blocks/basic.py
+++ b/autokeras/blocks/basic.py
@@ -789,11 +789,11 @@ class BertBlock(block_module.Block):
     ```python
         # Using the Transformer Block with AutoModel.
         import autokeras as ak
-        from autokeras import BERTBlock
+        from autokeras.blocks import BertBlock
         from tensorflow.keras import losses
 
         input_node = ak.TextInput()
-        output_node = BERTBlock(max_seq_len=128)(input_node)
+        output_node = BertBlock(max_sequence_length=128)(input_node)
         output_node = ak.ClassificationHead()(output_node)
         clf = ak.AutoModel(inputs=input_node, outputs=output_node, max_trials=10)
     ```

--- a/autokeras/blocks/basic.py
+++ b/autokeras/blocks/basic.py
@@ -789,7 +789,7 @@ class BertBlock(block_module.Block):
     ```python
         # Using the Transformer Block with AutoModel.
         import autokeras as ak
-        from autokeras.blocks import BertBlock
+        from autokeras import BertBlock
         from tensorflow.keras import losses
 
         input_node = ak.TextInput()


### PR DESCRIPTION
The comment example for BertBlock previously referred to paths that were no longer in the package. Further, the name of the parameter was not lining up with what is used in the package now. I have corrected the comment so people following the comments will not run into any issues. 