### PR TITLE
Changes to support the ability to do image in/ image out regression

### DIFF
--- a/autokeras/__init__.py
+++ b/autokeras/__init__.py
@@ -26,6 +26,7 @@ from autokeras.blocks import ImageBlock
 from autokeras.blocks import Merge
 from autokeras.blocks import Normalization
 from autokeras.blocks import RegressionHead
+from autokeras.blocks import FlexibleRegressionHead
 from autokeras.blocks import ResNetBlock
 from autokeras.blocks import RNNBlock
 from autokeras.blocks import SpatialReduction

--- a/autokeras/__init__.py
+++ b/autokeras/__init__.py
@@ -21,12 +21,12 @@ from autokeras.blocks import DenseBlock
 from autokeras.blocks import EfficientNetBlock
 from autokeras.blocks import Embedding
 from autokeras.blocks import Flatten
+from autokeras.blocks import FlexibleRegressionHead
 from autokeras.blocks import ImageAugmentation
 from autokeras.blocks import ImageBlock
 from autokeras.blocks import Merge
 from autokeras.blocks import Normalization
 from autokeras.blocks import RegressionHead
-from autokeras.blocks import FlexibleRegressionHead
 from autokeras.blocks import ResNetBlock
 from autokeras.blocks import RNNBlock
 from autokeras.blocks import SpatialReduction

--- a/autokeras/analysers/__init__.py
+++ b/autokeras/analysers/__init__.py
@@ -20,5 +20,5 @@ from autokeras.analysers.input_analysers import StructuredDataAnalyser
 from autokeras.analysers.input_analysers import TextAnalyser
 from autokeras.analysers.input_analysers import TimeseriesAnalyser
 from autokeras.analysers.output_analysers import ClassificationAnalyser
-from autokeras.analysers.output_analysers import RegressionAnalyser
 from autokeras.analysers.output_analysers import FlexibleAnalyser
+from autokeras.analysers.output_analysers import RegressionAnalyser

--- a/autokeras/analysers/__init__.py
+++ b/autokeras/analysers/__init__.py
@@ -21,3 +21,4 @@ from autokeras.analysers.input_analysers import TextAnalyser
 from autokeras.analysers.input_analysers import TimeseriesAnalyser
 from autokeras.analysers.output_analysers import ClassificationAnalyser
 from autokeras.analysers.output_analysers import RegressionAnalyser
+from autokeras.analysers.output_analysers import FlexibleAnalyser

--- a/autokeras/analysers/output_analysers.py
+++ b/autokeras/analysers/output_analysers.py
@@ -120,3 +120,15 @@ class RegressionAnalyser(TargetAnalyser):
         if len(self.shape) == 1:
             return 1
         return self.shape[1]
+    
+class FlexibleAnalyser(TargetAnalyser):
+    '''
+    This is an analyzer that goes with the flow and just allows whatever dimensions 
+    are provided by the data at this stage.
+    '''
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def finalize(self):
+        #Use whatever we have available
+        self.output_dim=self.shape

--- a/autokeras/analysers/output_analysers.py
+++ b/autokeras/analysers/output_analysers.py
@@ -120,15 +120,17 @@ class RegressionAnalyser(TargetAnalyser):
         if len(self.shape) == 1:
             return 1
         return self.shape[1]
-    
+
+
 class FlexibleAnalyser(TargetAnalyser):
-    '''
-    This is an analyzer that goes with the flow and just allows whatever dimensions 
+    """
+    This is an analyzer that goes with the flow and just allows whatever dimensions
     are provided by the data at this stage.
-    '''
+    """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
     def finalize(self):
-        #Use whatever we have available
-        self.output_dim=self.shape
+        # Use whatever we have available
+        self.output_dim = self.shape

--- a/autokeras/auto_model.py
+++ b/autokeras/auto_model.py
@@ -197,6 +197,10 @@ class AutoModel(object):
         elif all([isinstance(output, head_module.Head) for output in self.outputs]):
             graph = self._assemble()
             self.outputs = graph.outputs
+        else:
+            raise ValueError(
+                "AutoModel outputs should all be either an autokeras.Head or autokeras ak.Node."
+            )
 
         return graph
 

--- a/autokeras/auto_model.py
+++ b/autokeras/auto_model.py
@@ -217,8 +217,10 @@ class AutoModel(object):
         validation data.
 
         # Arguments
-            x: numpy.ndarray or tensorflow.Dataset. Training data x.
+            x: numpy.ndarray or tensorflow.Dataset. Training data x. 
+                If x is a tensorflow.Dataset, each element should be an in/out pair: (input, output).
             y: numpy.ndarray or tensorflow.Dataset. Training data y.
+                If x is a tensorflow.Dataset, this should be None.
             batch_size: Int. Number of samples per gradient update. Defaults to 32.
             epochs: Int. The number of epochs to train each model during the search.
                 If unspecified, by default we train for a maximum of 1000 epochs,

--- a/autokeras/auto_model.py
+++ b/autokeras/auto_model.py
@@ -199,7 +199,8 @@ class AutoModel(object):
             self.outputs = graph.outputs
         else:
             raise ValueError(
-                "AutoModel outputs should all be either an autokeras.Head or autokeras ak.Node."
+                "AutoModel outputs should all be either an autokeras.Head or"\
+                "autokeras ak.Node."
             )
 
         return graph
@@ -222,7 +223,8 @@ class AutoModel(object):
 
         # Arguments
             x: numpy.ndarray or tensorflow.Dataset. Training data x. 
-                If x is a tensorflow.Dataset, each element should be an in/out pair: (input, output).
+                If x is a tensorflow.Dataset, each element should be an in/out pair:
+                (input, output).
             y: numpy.ndarray or tensorflow.Dataset. Training data y.
                 If x is a tensorflow.Dataset, this should be None.
             batch_size: Int. Number of samples per gradient update. Defaults to 32.

--- a/autokeras/auto_model.py
+++ b/autokeras/auto_model.py
@@ -199,7 +199,7 @@ class AutoModel(object):
             self.outputs = graph.outputs
         else:
             raise ValueError(
-                "AutoModel outputs should all be either an autokeras.Head or"\
+                "AutoModel outputs should all be either an autokeras.Head or"
                 "autokeras ak.Node."
             )
 
@@ -222,7 +222,7 @@ class AutoModel(object):
         validation data.
 
         # Arguments
-            x: numpy.ndarray or tensorflow.Dataset. Training data x. 
+            x: numpy.ndarray or tensorflow.Dataset. Training data x.
                 If x is a tensorflow.Dataset, each element should be an in/out pair:
                 (input, output).
             y: numpy.ndarray or tensorflow.Dataset. Training data y.

--- a/autokeras/blocks/__init__.py
+++ b/autokeras/blocks/__init__.py
@@ -25,6 +25,7 @@ from autokeras.blocks.basic import Transformer
 from autokeras.blocks.basic import XceptionBlock
 from autokeras.blocks.heads import ClassificationHead
 from autokeras.blocks.heads import RegressionHead
+from autokeras.blocks.heads import FlexibleRegressionHead
 from autokeras.blocks.heads import SegmentationHead
 from autokeras.blocks.preprocessing import CategoricalToNumerical
 from autokeras.blocks.preprocessing import ImageAugmentation

--- a/autokeras/blocks/__init__.py
+++ b/autokeras/blocks/__init__.py
@@ -24,8 +24,8 @@ from autokeras.blocks.basic import RNNBlock
 from autokeras.blocks.basic import Transformer
 from autokeras.blocks.basic import XceptionBlock
 from autokeras.blocks.heads import ClassificationHead
-from autokeras.blocks.heads import RegressionHead
 from autokeras.blocks.heads import FlexibleRegressionHead
+from autokeras.blocks.heads import RegressionHead
 from autokeras.blocks.heads import SegmentationHead
 from autokeras.blocks.preprocessing import CategoricalToNumerical
 from autokeras.blocks.preprocessing import ImageAugmentation

--- a/autokeras/blocks/basic.py
+++ b/autokeras/blocks/basic.py
@@ -239,11 +239,11 @@ class ConvBlock(block_module.Block):
         dropout: Float. Between 0 and 1. The dropout rate for after the
             convolutional layers. If left unspecified, it will be tuned
             automatically.
-        padding: one of "valid", "same" (case-insensitive), or None. "valid" means 
-            no padding.  "same" results in padding evenly to the left/right or 
-            up/down of the input such that output has the same height/width dimension 
+        padding: one of "valid", "same" (case-insensitive), or None. "valid" means
+            no padding.  "same" results in padding evenly to the left/right or
+            up/down of the input such that output has the same height/width dimension
             as the input.  None means use a heuristic to choose this.
-        num_filters: The number of output filters in the convolution, or None to 
+        num_filters: The number of output filters in the convolution, or None to
             autotune.
     """
 
@@ -324,25 +324,29 @@ class ConvBlock(block_module.Block):
 
         for i in range(num_blocks):
             for j in range(num_layers):
-                
-                #Auto-choose num_filters if it is not specified:
+
+                # Auto-choose num_filters if it is not specified:
                 if self.num_filters is None:
-                    self.num_filters=hp.Choice(
+                    self.num_filters = hp.Choice(
                         "filters_{i}_{j}".format(i=i, j=j),
                         [16, 32, 64, 128, 256, 512],
                         default=32,
                     )
-                    
+
                 output_node = conv(
                     self.num_filters,
                     kernel_size,
-                    padding=self._get_padding(self.padding, kernel_size, output_node),
+                    padding=self._get_padding(
+                        self.padding, kernel_size, output_node
+                    ),
                     activation="relu",
                 )(output_node)
             if max_pooling:
                 output_node = pool(
                     kernel_size - 1,
-                    padding=self._get_padding(self.padding, kernel_size - 1, output_node),
+                    padding=self._get_padding(
+                        self.padding, kernel_size - 1, output_node
+                    ),
                 )(output_node)
             if dropout > 0:
                 output_node = layers.Dropout(dropout)(output_node)
@@ -350,14 +354,16 @@ class ConvBlock(block_module.Block):
 
     @staticmethod
     def _get_padding(padding, kernel_size, output_node):
-        '''
+        """
         Return the provided padding if it is set, or use a heuristic to choose it.
-        '''
-        
+        """
+
         if padding:
             return padding
         else:
-            if all([kernel_size * 2 <= length for length in output_node.shape[1:-1]]):
+            if all(
+                [kernel_size * 2 <= length for length in output_node.shape[1:-1]]
+            ):
                 return "valid"
             return "same"
 

--- a/autokeras/blocks/basic.py
+++ b/autokeras/blocks/basic.py
@@ -243,7 +243,8 @@ class ConvBlock(block_module.Block):
             no padding.  "same" results in padding evenly to the left/right or 
             up/down of the input such that output has the same height/width dimension 
             as the input.  None means use a heuristic to choose this.
-        num_filters: The number of output filters in the convolution, or None to autotune.
+        num_filters: The number of output filters in the convolution, or None to 
+            autotune.
     """
 
     def __init__(

--- a/autokeras/blocks/heads.py
+++ b/autokeras/blocks/heads.py
@@ -114,7 +114,7 @@ class ClassificationHead(head_module.Head):
 
         if dropout > 0:
             output_node = layers.Dropout(dropout)(output_node)
-            
+
         output_node = layers.Dense(self.shape[-1])(output_node)
         if isinstance(self.loss, tf.keras.losses.BinaryCrossentropy):
             output_node = layers.Activation(activations.sigmoid, name=self.name)(
@@ -219,9 +219,9 @@ class RegressionHead(head_module.Head):
         self.dropout = dropout
 
     def get_config(self):
-        '''
+        """
         Adds our config to the config we inherited.
-        '''
+        """
         config = super().get_config()
         config.update({"output_dim": self.output_dim, "dropout": self.dropout})
         return config
@@ -229,24 +229,24 @@ class RegressionHead(head_module.Head):
     def build(self, hp, inputs=None):
         """
         Builds the network.
-        
+
         hp: a kerastuner.hyperparameters.HyperParameters() object w/ hyperparameters.
         """
-        
+
         inputs = nest.flatten(inputs)
         utils.validate_num_inputs(inputs, 1)
-        
-        #Use only the first input:
+
+        # Use only the first input:
         input_node = inputs[0]
-        
-        #Initialize:
+
+        # Initialize:
         output_node = input_node
 
         dropout = self.dropout or hp.Choice("dropout", [0.0, 0.25, 0.5], default=0)
 
         if dropout > 0:
             output_node = layers.Dropout(dropout)(output_node)
-            
+
         output_node = reduction.Flatten().build(hp, output_node)
         output_node = layers.Dense(self.shape[-1], name=self.name)(output_node)
         return output_node
@@ -257,30 +257,30 @@ class RegressionHead(head_module.Head):
         # Arguments
             adapter: An instance of a subclass of autokeras.engine.Adapter.
         """
-        
+
         super().config_from_analyser(analyser)
-        
-        #If we only have one in our input data, add another at the end.
+
+        # If we only have one in our input data, add another at the end.
         self._add_one_dimension = len(analyser.shape) == 1
 
     def get_adapter(self):
         """Get the corresponding Adapter.
 
         # Returns
-            An instance of a subclass of autokeras.engine.Adapter, which checks, 
+            An instance of a subclass of autokeras.engine.Adapter, which checks,
             converts, and batchifies a dataset
         """
-        
+
         return adapters.RegressionAdapter(name=self.name)
 
     def get_analyser(self):
         """Get the corresponding Analyser.
 
         # Returns
-            An instance of a subclass of autokeras.engine.Analyser, which analyzes 
+            An instance of a subclass of autokeras.engine.Analyser, which analyzes
             input data to inform input nodes.
         """
-        
+
         return analysers.RegressionAnalyser(
             name=self.name, output_dim=self.output_dim
         )
@@ -289,16 +289,16 @@ class RegressionHead(head_module.Head):
         """Construct a list of HyperPreprocessors based on the learned information.
 
         # Returns
-            A list of HyperPreprocessors for the corresponding data, which define 
+            A list of HyperPreprocessors for the corresponding data, which define
             the search space for a Preprocessor.
         """
-        
+
         hyper_preprocessors = []
         if self._add_one_dimension:
             hyper_preprocessors.append(
                 hpps_module.DefaultHyperPreprocessor(preprocessors.AddOneDimension())
             )
-            
+
         return hyper_preprocessors
 
 
@@ -320,33 +320,33 @@ class FlexibleRegressionHead(head_module.Head):
     ):
         if metrics is None:
             metrics = ["mean_squared_error"]
-            
+
         super().__init__(loss=loss, metrics=metrics, **kwargs)
 
     def get_config(self):
-        '''
+        """
         Adds our config to the config we inherited.
-        '''
+        """
         config = super().get_config()
         return config
 
     def build(self, hp, inputs=None):
         """
         Builds the network.
-        
+
         hp: a kerastuner.hyperparameters.HyperParameters() object w/ hyperparameters.
         """
-        
+
         inputs = nest.flatten(inputs)
         utils.validate_num_inputs(inputs, 1)
-        
-        #Use only the first input:
+
+        # Use only the first input:
         input_node = inputs[0]
-        
-        #Put an identity layer in place so we can name the ouptut to prevent an err:
-        identity=tf.keras.layers.Layer(name=self.name)
-        output_node=identity(input_node)
-        
+
+        # Put an identity layer in place so we can name the ouptut to prevent an err:
+        identity = tf.keras.layers.Layer(name=self.name)
+        output_node = identity(input_node)
+
         return output_node
 
     def config_from_analyser(self, analyser):
@@ -355,39 +355,39 @@ class FlexibleRegressionHead(head_module.Head):
         # Arguments
             adapter: An instance of a subclass of autokeras.engine.Adapter.
         """
-        
+
         super().config_from_analyser(analyser)
-        
+
     def get_adapter(self):
         """Get the corresponding Adapter.
 
         # Returns
-            An instance of a subclass of autokeras.engine.Adapter, which checks, 
+            An instance of a subclass of autokeras.engine.Adapter, which checks,
             converts, and batchifies a dataset
         """
-        
+
         return adapters.RegressionAdapter(name=self.name)
 
     def get_analyser(self):
         """Get the corresponding Analyser.
 
         # Returns
-            An instance of a subclass of autokeras.engine.Analyser, which analyzes 
+            An instance of a subclass of autokeras.engine.Analyser, which analyzes
             input data to inform input nodes.
         """
-        
+
         return analysers.FlexibleAnalyser(name=self.name)
 
     def get_hyper_preprocessors(self):
         """Construct a list of HyperPreprocessors based on the learned information.
 
         # Returns
-            A list of HyperPreprocessors for the corresponding data, which define 
+            A list of HyperPreprocessors for the corresponding data, which define
             the search space for a Preprocessor.
         """
-        
+
         hyper_preprocessors = []
-            
+
         return hyper_preprocessors
 
 

--- a/autokeras/blocks/heads.py
+++ b/autokeras/blocks/heads.py
@@ -230,8 +230,7 @@ class RegressionHead(head_module.Head):
         """
         Builds the network.
         
-        hp: a kerastuner.hyperparameters.HyperParameters() object specifying our hyperparameters.
-        Docs: https://github.com/keras-team/keras-tuner/blob/master/kerastuner/engine/hyperparameters.py
+        hp: a kerastuner.hyperparameters.HyperParameters() object w/ hyperparameters.
         """
         
         inputs = nest.flatten(inputs)
@@ -306,7 +305,7 @@ class RegressionHead(head_module.Head):
 class FlexibleRegressionHead(head_module.Head):
     """Regression layers for a general output (for example an Image).
 
-    The targets passing to the head would have to be whatever is expected at the output.
+    The shape of the input needs to be what is expected at the output.
 
     # Arguments
         loss: A Keras loss function. Defaults to use `mean_squared_error`.
@@ -335,8 +334,7 @@ class FlexibleRegressionHead(head_module.Head):
         """
         Builds the network.
         
-        hp: a kerastuner.hyperparameters.HyperParameters() object specifying our hyperparameters.
-        Docs: https://github.com/keras-team/keras-tuner/blob/master/kerastuner/engine/hyperparameters.py
+        hp: a kerastuner.hyperparameters.HyperParameters() object w/ hyperparameters.
         """
         
         inputs = nest.flatten(inputs)
@@ -345,7 +343,7 @@ class FlexibleRegressionHead(head_module.Head):
         #Use only the first input:
         input_node = inputs[0]
         
-        #Put an identity layer in place because we need to name our output so the names match later:
+        #Put an identity layer in place so we can name the ouptut and prevent an err:
         identity=tf.keras.layers.Layer(name=self.name)
         output_node=identity(input_node)
         

--- a/autokeras/blocks/heads.py
+++ b/autokeras/blocks/heads.py
@@ -343,7 +343,7 @@ class FlexibleRegressionHead(head_module.Head):
         #Use only the first input:
         input_node = inputs[0]
         
-        #Put an identity layer in place so we can name the ouptut and prevent an err:
+        #Put an identity layer in place so we can name the ouptut to prevent an err:
         identity=tf.keras.layers.Layer(name=self.name)
         output_node=identity(input_node)
         

--- a/autokeras/engine/adapter.py
+++ b/autokeras/engine/adapter.py
@@ -21,7 +21,7 @@ from autokeras.utils import data_utils
 class Adapter(object):
     """Adpat the input and output format for Keras Model.
 
-    Adapter is used by the input nodes and the heads of the hypermodel. It do
+    Adapter is used by the input nodes and the heads of the hypermodel. It does
     some type checking for the data and converts it to tf.data.Dataset format.
     It also batches the dataset if it is not batched.
     """

--- a/autokeras/engine/block.py
+++ b/autokeras/engine/block.py
@@ -56,7 +56,7 @@ class Block(named_hypermodel.NamedHyperModel):
                     )
                 )
                     
-            #Add this node to the graph by making this node as an output of the input:
+            #Add this node to the graph by making this node an output of the input:
             input_node.add_out_block(self)
         self.outputs = []
         

--- a/autokeras/engine/block.py
+++ b/autokeras/engine/block.py
@@ -55,17 +55,17 @@ class Block(named_hypermodel.NamedHyperModel):
                         name=self.name, type=type(input_node)
                     )
                 )
-                    
-            #Add this node to the graph by making this node an output of the input:
+
+            # Add this node to the graph by making this node an output of the input:
             input_node.add_out_block(self)
         self.outputs = []
-        
-        #Connect this block to the output node's inputs as well:
+
+        # Connect this block to the output node's inputs as well:
         for _ in range(self._num_output_node):
             output_node = node_module.Node()
             output_node.add_in_block(self)
             self.outputs.append(output_node)
-            
+
         return self.outputs
 
     def build(self, hp, inputs=None):

--- a/autokeras/engine/block.py
+++ b/autokeras/engine/block.py
@@ -55,12 +55,17 @@ class Block(named_hypermodel.NamedHyperModel):
                         name=self.name, type=type(input_node)
                     )
                 )
+                    
+            #Add this node to the graph by making this node as an output of the input:
             input_node.add_out_block(self)
         self.outputs = []
+        
+        #Connect this block to the output node's inputs as well:
         for _ in range(self._num_output_node):
             output_node = node_module.Node()
             output_node.add_in_block(self)
             self.outputs.append(output_node)
+            
         return self.outputs
 
     def build(self, hp, inputs=None):

--- a/autokeras/engine/head.py
+++ b/autokeras/engine/head.py
@@ -68,7 +68,9 @@ class Head(io_hypermodel.IOHyperModel):
         **kwargs
     ):
         super().__init__(**kwargs)
+        
         self.loss = loss
+        
         if metrics is None:
             metrics = []
         self.metrics = metrics
@@ -86,6 +88,8 @@ class Head(io_hypermodel.IOHyperModel):
 
     @classmethod
     def from_config(cls, config):
+        '''Build an instance from the config of this object.'''
+        
         config["loss"] = deserialize_loss(config["loss"])
         config["metrics"] = deserialize_metrics(config["metrics"])
         return super().from_config(config)

--- a/autokeras/engine/head.py
+++ b/autokeras/engine/head.py
@@ -68,9 +68,9 @@ class Head(io_hypermodel.IOHyperModel):
         **kwargs
     ):
         super().__init__(**kwargs)
-        
+
         self.loss = loss
-        
+
         if metrics is None:
             metrics = []
         self.metrics = metrics
@@ -88,8 +88,8 @@ class Head(io_hypermodel.IOHyperModel):
 
     @classmethod
     def from_config(cls, config):
-        '''Build an instance from the config of this object.'''
-        
+        """Build an instance from the config of this object."""
+
         config["loss"] = deserialize_loss(config["loss"])
         config["metrics"] = deserialize_metrics(config["metrics"])
         return super().from_config(config)

--- a/autokeras/engine/io_hypermodel.py
+++ b/autokeras/engine/io_hypermodel.py
@@ -35,7 +35,8 @@ class IOHyperModel(block_module.Block):
         """Get the corresponding Analyser.
 
         # Returns
-            An instance of a subclass of autokeras.engine.Analyser.
+            An instance of a subclass of autokeras.engine.Analyser, which analyzes 
+            input data to inform input nodes.
         """
         raise NotImplementedError
 
@@ -43,7 +44,8 @@ class IOHyperModel(block_module.Block):
         """Get the corresponding Adapter.
 
         # Returns
-            An instance of a subclass of autokeras.engine.Adapter.
+            An instance of a subclass of autokeras.engine.Adapter, which checks, 
+            converts, and batchifies a dataset
         """
         raise NotImplementedError
 
@@ -62,7 +64,8 @@ class IOHyperModel(block_module.Block):
         """Construct a list of HyperPreprocessors based on the learned information.
 
         # Returns
-            A list of HyperPreprocessors for the corresponding data.
+            A list of HyperPreprocessors for the corresponding data, which define 
+            the search space for a Preprocessor.
         """
         raise NotImplementedError
 

--- a/autokeras/engine/io_hypermodel.py
+++ b/autokeras/engine/io_hypermodel.py
@@ -35,7 +35,7 @@ class IOHyperModel(block_module.Block):
         """Get the corresponding Analyser.
 
         # Returns
-            An instance of a subclass of autokeras.engine.Analyser, which analyzes 
+            An instance of a subclass of autokeras.engine.Analyser, which analyzes
             input data to inform input nodes.
         """
         raise NotImplementedError
@@ -44,7 +44,7 @@ class IOHyperModel(block_module.Block):
         """Get the corresponding Adapter.
 
         # Returns
-            An instance of a subclass of autokeras.engine.Adapter, which checks, 
+            An instance of a subclass of autokeras.engine.Adapter, which checks,
             converts, and batchifies a dataset
         """
         raise NotImplementedError
@@ -64,7 +64,7 @@ class IOHyperModel(block_module.Block):
         """Construct a list of HyperPreprocessors based on the learned information.
 
         # Returns
-            A list of HyperPreprocessors for the corresponding data, which define 
+            A list of HyperPreprocessors for the corresponding data, which define
             the search space for a Preprocessor.
         """
         raise NotImplementedError

--- a/autokeras/engine/preprocessor.py
+++ b/autokeras/engine/preprocessor.py
@@ -33,7 +33,7 @@ class Preprocessor(serializable.Serializable):
         pass
 
     def transform(self, dataset):
-        """Transform the dataset wth the preprocessor.
+        """Transform the dataset with the preprocessor.
 
         # Arguments
             dataset: an instance of `tf.data.Dataset`.


### PR DESCRIPTION
### Which issue(s) does this Pull Request fix?
resolves #1429

### Details of the Pull Request
I needed a way to create a neural network that could take an image as input and create an image as the output.  autokeras as it was did not seem to support this yet.  I made these modifications so that it can be supported.  Please take a look and see if they make sense to you.

Here's how it can be used:

```python
batchSize=10

nodeInput=ak.ImageInput()
#Initialize:
nodeOutput=nodeInput

nodeOutput=ak.ConvBlock(max_pooling=False, padding='same')(nodeOutput)
#Make sure we go down to one filter at the end:
nodeOutput=ak.ConvBlock(num_layers=1, num_blocks=1, num_filters=1, max_pooling=False, padding='same')(nodeOutput)
nodeOutput=ak.FlexibleRegressionHead()(nodeOutput)

#Define the model to be made automatically with an image input and and image output:
autoModel=ak.AutoModel(
    inputs=[nodeInput],
    outputs=[nodeOutput],
    project_name='bdModel',
    directory=checkpointDir,
    overwrite=not recover,
    seed=s.seed,
    max_trials=maxTrials,
    )

#Fit the model:
#Additional parameters accepted:
#https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit
#Ones to play with: class_weight, 
autoModel.fit(trainingData, 
                None, 
                batch_size=batchSize,
                epochs=epochs,
                validation_data=validationData)
```