### PR TITLE
Updated keras tuner version, removed 1.0.2rc4 suffix because the lates…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For detailed tutorial, please check [here](https://autokeras.com/tutorial/overvi
 To install the package, please use the `pip` installation as follows:
 
 ```shell
-pip3 install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip3 install git+https://github.com/keras-team/keras-tuner.git
 pip3 install autokeras
 ```
 

--- a/docs/ipynb/customized.ipynb
+++ b/docs/ipynb/customized.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/ipynb/export.ipynb
+++ b/docs/ipynb/export.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/ipynb/image_classification.ipynb
+++ b/docs/ipynb/image_classification.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/ipynb/image_regression.ipynb
+++ b/docs/ipynb/image_regression.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/ipynb/load.ipynb
+++ b/docs/ipynb/load.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/ipynb/multi.ipynb
+++ b/docs/ipynb/multi.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/ipynb/structured_data_classification.ipynb
+++ b/docs/ipynb/structured_data_classification.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/ipynb/structured_data_regression.ipynb
+++ b/docs/ipynb/structured_data_regression.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/ipynb/text_classification.ipynb
+++ b/docs/ipynb/text_classification.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/ipynb/text_regression.ipynb
+++ b/docs/ipynb/text_regression.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "!pip install autokeras\n",
-    "!pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4\n"
+    "!pip install git+https://github.com/keras-team/keras-tuner.git\n"
    ]
   },
   {

--- a/docs/py/customized.py
+++ b/docs/py/customized.py
@@ -1,6 +1,6 @@
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 """

--- a/docs/py/export.py
+++ b/docs/py/export.py
@@ -9,7 +9,7 @@ All the tasks and the [AutoModel](/auto_model/#automodel-class) has this
 
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 import tensorflow as tf

--- a/docs/py/image_classification.py
+++ b/docs/py/image_classification.py
@@ -1,6 +1,6 @@
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 """

--- a/docs/py/image_regression.py
+++ b/docs/py/image_regression.py
@@ -1,6 +1,6 @@
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 """

--- a/docs/py/load.py
+++ b/docs/py/load.py
@@ -1,6 +1,6 @@
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 """

--- a/docs/py/multi.py
+++ b/docs/py/multi.py
@@ -1,6 +1,6 @@
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 """

--- a/docs/py/structured_data_classification.py
+++ b/docs/py/structured_data_classification.py
@@ -1,6 +1,6 @@
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 """

--- a/docs/py/structured_data_regression.py
+++ b/docs/py/structured_data_regression.py
@@ -1,6 +1,6 @@
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 """

--- a/docs/py/text_classification.py
+++ b/docs/py/text_classification.py
@@ -1,6 +1,6 @@
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 """

--- a/docs/py/text_regression.py
+++ b/docs/py/text_regression.py
@@ -1,6 +1,6 @@
 """shell
 pip install autokeras
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 """
 
 """

--- a/docs/templates/install.md
+++ b/docs/templates/install.md
@@ -17,14 +17,14 @@ AutoKeras only support **Python 3**.
 If you followed previous steps to use virtualenv to install tensorflow,
 you can just activate the virtualenv and use the following command to install AutoKeras. 
 ```
-pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+pip install git+https://github.com/keras-team/keras-tuner.git
 pip install autokeras
 ```
 
 If you did not use virtualenv, and you use `python3` command to execute your python program,
 please use the following command to install AutoKeras.
 ```
-python3 -m pip install git+https://github.com/keras-team/keras-tuner.git@1.0.2rc4
+python3 -m pip install git+https://github.com/keras-team/keras-tuner.git
 python3 -m pip install autokeras
 ```
 


### PR DESCRIPTION
Updated keras tuner installation url to the latest release, removed the @1.0.2rc4 suffix from the url because the final release is already available.