### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/autokeras/keras_layers.py
+++ b/autokeras/keras_layers.py
@@ -1395,7 +1395,7 @@ def _build_attention_equation(qkv_rank, attn_axes):
 class MaskedSoftmax(tf.keras.layers.Layer):
     """Performs a softmax with optional masking on a tensor.
 
-    Arguments:
+    Args:
       mask_expansion_axes: Any axes that should be padded on the mask tensor.
       normalization_axes: On which axes the softmax should perform.
     """


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420