### PR TITLE
Simple path fix in docs .md file

### DIFF
--- a/docs/templates/docker.md
+++ b/docs/templates/docker.md
@@ -47,5 +47,5 @@ curl https://raw.githubusercontent.com/keras-team/autokeras/master/examples/mnis
 
 Run the mnist example :
 ```
-docker run -it -v "$(pwd)":/app --shm-size 2G haifengjin/autokeras python mnist.py
+docker run -it -v "$(pwd)":/app --shm-size 2G haifengjin/autokeras python /app/mnist.py
 ```


### PR DESCRIPTION
fix the path in the example pointing to the mnist.py file. 

problem: The docker container can't find mnist.py as it is mounted under the ```/app``` folder