### PR TITLE
use values instead of Fixed for user specified hp value

### DIFF
--- a/autokeras/utils/utils.py
+++ b/autokeras/utils/utils.py
@@ -16,7 +16,6 @@ import re
 
 import kerastuner
 import tensorflow as tf
-from kerastuner.engine import hyperparameters
 from packaging.version import parse
 from tensorflow.python.util import nest
 
@@ -114,8 +113,6 @@ def run_with_adaptive_batch_size(batch_size, func, **fit_kwargs):
 def get_hyperparameter(value, hp, dtype):
     if value is None:
         return hp
-    elif isinstance(value, dtype):
-        return hyperparameters.Fixed(hp.name, value)
     return value
 
 
@@ -126,6 +123,8 @@ def add_to_hp(hp, hps, name=None):
         hp: kerastuner.HyperParameters.
         name: String. If left unspecified, the hp name is used.
     """
+    if not isinstance(hp, kerastuner.engine.hyperparameters.HyperParameter):
+        return hp
     kwargs = hp.get_config()
     if name is None:
         name = hp.name

--- a/tests/unit_tests/utils/utils_test.py
+++ b/tests/unit_tests/utils/utils_test.py
@@ -65,9 +65,10 @@ def test_get_hyperparameter_with_none_return_hp():
     assert isinstance(hp, hyperparameters.Choice)
 
 
-def test_get_hyperparameter_with_int_return_fixed():
-    hp = utils.get_hyperparameter(10, hyperparameters.Choice("hp", [10, 20]), int)
-    assert isinstance(hp, hyperparameters.Fixed)
+def test_get_hyperparameter_with_int_return_int():
+    value = utils.get_hyperparameter(10, hyperparameters.Choice("hp", [10, 20]), int)
+    assert isinstance(value, int)
+    assert value == 10
 
 
 def test_get_hyperparameter_with_hp_return_same():


### PR DESCRIPTION
<!-- STEP 1: Give the pull request a meaningful title. -->
### Which issue(s) does this Pull Request fix?
<!-- STEP 2: Replace the "000" with the issue ID this pull request resolves. -->
resolves #000

### Details of the Pull Request
<!-- STEP 3: Add details/comments on the pull request. -->
The original implementation converts the user-provided value to the `Fixed` type if the user specifies a concrete value for the hp when initializing the block.

It causes a bug because some blocks are initialized not by the user, but inside the `build` function of other blocks.
Therefore, such blocks would be initialized multiple times with different `Fixed` values with different values.
However, the Keras Tuner would only record the first initialization of a hyperparameter and retrieve the same value for the rest of the initializations.
<!-- STEP 4: If the pull request is in progress, click the down green arrow to select "Create Draft Pull Request", and click the button. If the pull request is ready to be reviewed, click "Create Pull Request" button directly. -->
