### PR TITLE
Added Explicit Verbose Options #1286

### DIFF
--- a/autokeras/engine/tuner.py
+++ b/autokeras/engine/tuner.py
@@ -134,7 +134,14 @@ class AutoTuner(kerastuner.engine.tuner.Tuner):
                 layer = get_output_layer(layer.output)
         return model
 
-    def search(self, epochs=None, callbacks=None, validation_split=0, **fit_kwargs):
+    def search(
+        self,
+        epochs=None,
+        callbacks=None,
+        validation_split=0,
+        verbose=1,
+        **fit_kwargs
+    ):
         """Search for the best HyperParameters.
 
         If there is not early-stopping in the callbacks, the early-stopping callback
@@ -178,7 +185,11 @@ class AutoTuner(kerastuner.engine.tuner.Tuner):
         self.hypermodel.build(hp)
         self.oracle.update_space(hp)
 
-        super().search(epochs=epochs, callbacks=new_callbacks, **fit_kwargs)
+        super().search(
+            epochs=epochs,
+            callbacks=new_callbacks,
+            verbose=verbose,
+            **fit_kwargs)
 
         # Train the best model use validation data.
         # Train the best model with enough number of epochs.

--- a/autokeras/engine/tuner.py
+++ b/autokeras/engine/tuner.py
@@ -186,10 +186,8 @@ class AutoTuner(kerastuner.engine.tuner.Tuner):
         self.oracle.update_space(hp)
 
         super().search(
-            epochs=epochs,
-            callbacks=new_callbacks,
-            verbose=verbose,
-            **fit_kwargs)
+            epochs=epochs, callbacks=new_callbacks, verbose=verbose, **fit_kwargs
+        )
 
         # Train the best model use validation data.
         # Train the best model with enough number of epochs.

--- a/autokeras/utils/utils.py
+++ b/autokeras/utils/utils.py
@@ -67,9 +67,7 @@ def evaluate_with_adaptive_batch_size(model, batch_size, verbose=1, **fit_kwargs
     return run_with_adaptive_batch_size(
         batch_size,
         lambda x, validation_data, **kwargs: model.evaluate(
-            x,
-            verbose=verbose,
-            **kwargs
+            x, verbose=verbose, **kwargs
         ),
         **fit_kwargs
     )
@@ -79,9 +77,7 @@ def predict_with_adaptive_batch_size(model, batch_size, verbose=1, **fit_kwargs)
     return run_with_adaptive_batch_size(
         batch_size,
         lambda x, validation_data, **kwargs: model.predict(
-            x,
-            verbose=verbose,
-            **kwargs
+            x, verbose=verbose, **kwargs
         ),
         **fit_kwargs
     )

--- a/autokeras/utils/utils.py
+++ b/autokeras/utils/utils.py
@@ -63,18 +63,26 @@ def contain_instance(instance_list, instance_type):
     return any([isinstance(instance, instance_type) for instance in instance_list])
 
 
-def evaluate_with_adaptive_batch_size(model, batch_size, **fit_kwargs):
+def evaluate_with_adaptive_batch_size(model, batch_size, verbose=1, **fit_kwargs):
     return run_with_adaptive_batch_size(
         batch_size,
-        lambda x, validation_data, **kwargs: model.evaluate(x, **kwargs),
+        lambda x, validation_data, **kwargs: model.evaluate(
+            x,
+            verbose=verbose,
+            **kwargs
+        ),
         **fit_kwargs
     )
 
 
-def predict_with_adaptive_batch_size(model, batch_size, **fit_kwargs):
+def predict_with_adaptive_batch_size(model, batch_size, verbose=1, **fit_kwargs):
     return run_with_adaptive_batch_size(
         batch_size,
-        lambda x, validation_data, **kwargs: model.predict(x, **kwargs),
+        lambda x, validation_data, **kwargs: model.predict(
+            x,
+            verbose=verbose,
+            **kwargs
+        ),
         **fit_kwargs
     )
 


### PR DESCRIPTION
Fixes #1286. 
Added explicit verbose option to fit, predict and evaluate under AutoModel that are passed on to the respective KerasTuner functions and utils functions. 
Updated the docstrings for these functions as well. 