### PR TITLE
Fix dropout of RegressionHead

### DIFF
--- a/autokeras/blocks/heads.py
+++ b/autokeras/blocks/heads.py
@@ -228,7 +228,10 @@ class RegressionHead(head_module.Head):
         input_node = inputs[0]
         output_node = input_node
 
-        dropout = self.dropout or hp.Choice("dropout", [0.0, 0.25, 0.5], default=0)
+        if self.dropout is not None:
+            dropout = self.dropout
+        else:
+            dropout = hp.Choice("dropout", [0.0, 0.25, 0.5], default=0)
 
         if dropout > 0:
             output_node = layers.Dropout(dropout)(output_node)

--- a/tests/unit_tests/blocks/heads_test.py
+++ b/tests/unit_tests/blocks/heads_test.py
@@ -119,6 +119,17 @@ def test_clf_head_hpps_with_uint8_contain_cast_to_int32():
     )
 
 
+def test_reg_head_build_with_zero_dropout_return_tensor():
+    block = head_module.RegressionHead(dropout=0, shape=(8,))
+
+    outputs = block.build(
+        kerastuner.HyperParameters(),
+        tf.keras.Input(shape=(5,), dtype=tf.float32),
+    )
+
+    assert len(nest.flatten(outputs)) == 1
+
+
 def test_segmentation():
     dataset = np.array(["a", "a", "c", "b"])
     head = head_module.SegmentationHead(name="a", shape=(1,))


### PR DESCRIPTION
### Which issue(s) does this Pull Request fix?
resolves #000

### Details of the Pull Request
In RegressionHead, I found a problem that automatic tuning occurs when dropout is specified as 0, so I fixed it.
