### PR TITLE
Bug fix for compatibility issue with kt 1.1.0

### DIFF
--- a/autokeras/auto_model.py
+++ b/autokeras/auto_model.py
@@ -195,6 +195,9 @@ class AutoModel(object):
         elif all([isinstance(output, head_module.Head) for output in self.outputs]):
             # Clear session to reset get_uid(). The names of the blocks will
             # start to count from 1 for new blocks in a new AutoModel afterwards.
+            # When initializing multiple AutoModel with Task API, if not
+            # counting from 1 for each of the AutoModel, the predefined hp
+            # values in task specifiec tuners would not match the names.
             tf.keras.backend.clear_session()
             graph = self._assemble()
             self.outputs = graph.outputs

--- a/autokeras/engine/tuner.py
+++ b/autokeras/engine/tuner.py
@@ -88,7 +88,7 @@ class AutoTuner(keras_tuner.engine.tuner.Tuner):
         return pipeline, dataset, validation_data
 
     def _build_and_fit_model(self, trial, *args, **kwargs):
-        model = self.hypermodel.build(trial.hyperparameters)
+        model = self._try_build(trial.hyperparameters)
         (
             pipeline,
             kwargs["x"],
@@ -188,7 +188,7 @@ class AutoTuner(keras_tuner.engine.tuner.Tuner):
         # Populate initial search space.
         hp = self.oracle.get_space()
         self._prepare_model_build(hp, **fit_kwargs)
-        self.hypermodel.build(hp)
+        self._try_build(hp)
         self.oracle.update_space(hp)
         super().search(
             epochs=epochs, callbacks=new_callbacks, verbose=verbose, **fit_kwargs
@@ -255,7 +255,7 @@ class AutoTuner(keras_tuner.engine.tuner.Tuner):
     def _build_best_model(self):
         best_trial = self.oracle.get_best_trials(1)[0]
         best_hp = best_trial.hyperparameters
-        return self.hypermodel.build(best_hp)
+        return self._try_build(best_hp)
 
     def final_fit(self, **kwargs):
         best_trial = self.oracle.get_best_trials(1)[0]


### PR DESCRIPTION
Use `_try_build()` to build the `hypermodel` instead of build directly.
It would help using the distribution strategy and clear sessions for naming of the blocks.
Addressing this change:
https://github.com/keras-team/keras-tuner/pull/623/files