### PR TITLE
clean up imports

### DIFF
--- a/autokeras/auto_model.py
+++ b/autokeras/auto_model.py
@@ -20,6 +20,7 @@ from typing import Union
 
 import numpy as np
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 
 from autokeras import blocks
@@ -198,10 +199,10 @@ class AutoModel(object):
             # When initializing multiple AutoModel with Task API, if not
             # counting from 1 for each of the AutoModel, the predefined hp
             # values in task specifiec tuners would not match the names.
-            tf.keras.backend.clear_session()
+            keras.backend.clear_session()
             graph = self._assemble()
             self.outputs = graph.outputs
-            tf.keras.backend.clear_session()
+            keras.backend.clear_session()
 
         return graph
 
@@ -496,7 +497,7 @@ class AutoModel(object):
         """Export the best Keras Model.
 
         # Returns
-            tf.keras.Model instance. The best model found during the search, loaded
+            keras.Model instance. The best model found during the search, loaded
             with trained weights.
         """
         return self.tuner.get_best_model()

--- a/autokeras/blocks/__init__.py
+++ b/autokeras/blocks/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
+from tensorflow import keras
 
 from autokeras.blocks.basic import BertBlock
 from autokeras.blocks.basic import ConvBlock
@@ -43,11 +44,11 @@ from autokeras.blocks.wrapper import TimeseriesBlock
 
 
 def serialize(obj):
-    return tf.keras.utils.serialize_keras_object(obj)
+    return keras.utils.serialize_keras_object(obj)
 
 
 def deserialize(config, custom_objects=None):
-    return tf.keras.utils.deserialize_keras_object(
+    return keras.utils.deserialize_keras_object(
         config,
         module_objects=globals(),
         custom_objects=custom_objects,

--- a/autokeras/blocks/basic.py
+++ b/autokeras/blocks/basic.py
@@ -17,6 +17,7 @@ from typing import Union
 
 import tensorflow as tf
 from keras_tuner.engine import hyperparameters
+from tensorflow import keras
 from tensorflow import nest
 from tensorflow.keras import applications
 from tensorflow.keras import layers
@@ -594,7 +595,7 @@ class Transformer(block_module.Block):
         dense_dim = utils.add_to_hp(self.dense_dim, hp)
         dropout = utils.add_to_hp(self.dropout, hp)
 
-        ffn = tf.keras.Sequential(
+        ffn = keras.Sequential(
             [
                 layers.Dense(dense_dim, activation="relu"),
                 layers.Dense(embedding_dim),
@@ -622,16 +623,16 @@ class Transformer(block_module.Block):
             embedding_dim=embedding_dim,
             dropout=dropout,
         ).build(hp, positions)
-        output_node = tf.keras.layers.Add()([token_embedding, position_embedding])
+        output_node = keras.layers.Add()([token_embedding, position_embedding])
         attn_output = MultiHeadSelfAttention(embedding_dim, num_heads).build(
             hp, output_node
         )
         attn_output = dropout1(attn_output)
-        add_inputs_1 = tf.keras.layers.Add()([output_node, attn_output])
+        add_inputs_1 = keras.layers.Add()([output_node, attn_output])
         out1 = layernorm1(add_inputs_1)
         ffn_output = ffn(out1)
         ffn_output = dropout2(ffn_output)
-        add_inputs_2 = tf.keras.layers.Add()([out1, ffn_output])
+        add_inputs_2 = keras.layers.Add()([out1, ffn_output])
         return layernorm2(add_inputs_2)
 
     @staticmethod
@@ -686,7 +687,7 @@ class KerasApplicationBlock(block_module.Block):
         if hp.Boolean("imagenet_size", default=False):
             min_size = 224
         if input_node.shape[1] < min_size or input_node.shape[2] < min_size:
-            input_node = layers.experimental.preprocessing.Resizing(
+            input_node = layers.Resizing(
                 max(min_size, input_node.shape[1]),
                 max(min_size, input_node.shape[2]),
             )(input_node)

--- a/autokeras/blocks/basic_test.py
+++ b/autokeras/blocks/basic_test.py
@@ -15,6 +15,7 @@
 import keras_tuner
 import pytest
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 
 from autokeras import blocks
@@ -26,7 +27,7 @@ def test_resnet_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -37,7 +38,7 @@ def test_resnet_v1_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -48,7 +49,7 @@ def test_efficientnet_b0_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -59,7 +60,7 @@ def test_resnet_pretrained_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -70,7 +71,7 @@ def test_resnet_pretrained_with_one_channel_input():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(28, 28, 1), dtype=tf.float32),
+        keras.Input(shape=(28, 28, 1), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -82,7 +83,7 @@ def test_resnet_pretrained_error_with_two_channels():
     with pytest.raises(ValueError) as info:
         block.build(
             keras_tuner.HyperParameters(),
-            tf.keras.Input(shape=(224, 224, 2), dtype=tf.float32),
+            keras.Input(shape=(224, 224, 2), dtype=tf.float32),
         )
 
     assert "When pretrained is set to True" in str(info.value)
@@ -125,7 +126,7 @@ def test_xception_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 2), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 2), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -136,7 +137,7 @@ def test_xception_pretrained_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -147,7 +148,7 @@ def test_xception_pretrained_with_one_channel_input():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(224, 224, 1), dtype=tf.float32),
+        keras.Input(shape=(224, 224, 1), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -159,7 +160,7 @@ def test_xception_pretrained_error_with_two_channels():
     with pytest.raises(ValueError) as info:
         block.build(
             keras_tuner.HyperParameters(),
-            tf.keras.Input(shape=(224, 224, 2), dtype=tf.float32),
+            keras.Input(shape=(224, 224, 2), dtype=tf.float32),
         )
 
     assert "When pretrained is set to True" in str(info.value)
@@ -188,7 +189,7 @@ def test_conv_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -199,7 +200,7 @@ def test_conv_with_small_image_size_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(10, 10, 3), dtype=tf.float32),
+        keras.Input(shape=(10, 10, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -210,7 +211,7 @@ def test_conv_build_with_dropout_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -239,7 +240,7 @@ def test_rnn_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 10), dtype=tf.float32),
+        keras.Input(shape=(32, 10), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -251,7 +252,7 @@ def test_rnn_input_shape_one_dim_error():
     with pytest.raises(ValueError) as info:
         block.build(
             keras_tuner.HyperParameters(),
-            tf.keras.Input(shape=(32,), dtype=tf.float32),
+            keras.Input(shape=(32,), dtype=tf.float32),
         )
 
     assert "Expect the input tensor of RNNBlock" in str(info.value)
@@ -279,7 +280,7 @@ def test_dense_build_return_tensor():
     )
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(32,), dtype=tf.float32)
+        keras_tuner.HyperParameters(), keras.Input(shape=(32,), dtype=tf.float32)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -289,7 +290,7 @@ def test_dense_build_with_dropout_return_tensor():
     block = blocks.DenseBlock(dropout=0.5)
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(32,), dtype=tf.float32)
+        keras_tuner.HyperParameters(), keras.Input(shape=(32,), dtype=tf.float32)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -299,7 +300,7 @@ def test_dense_build_with_bn_return_tensor():
     block = blocks.DenseBlock(use_batchnorm=True)
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(32,), dtype=tf.float32)
+        keras_tuner.HyperParameters(), keras.Input(shape=(32,), dtype=tf.float32)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -327,7 +328,7 @@ def test_embed_build_return_tensor():
     block = blocks.Embedding()
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(32,), dtype=tf.float32)
+        keras_tuner.HyperParameters(), keras.Input(shape=(32,), dtype=tf.float32)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -355,7 +356,7 @@ def test_transformer_build_return_tensor():
     block = blocks.Transformer()
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(64,), dtype=tf.float32)
+        keras_tuner.HyperParameters(), keras.Input(shape=(64,), dtype=tf.float32)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -391,7 +392,7 @@ def test_bert_build_return_tensor():
     block = blocks.BertBlock()
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(1,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(1,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1

--- a/autokeras/blocks/heads.py
+++ b/autokeras/blocks/heads.py
@@ -15,6 +15,7 @@
 from typing import Optional
 
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 from tensorflow.keras import activations
 from tensorflow.keras import layers
@@ -115,7 +116,7 @@ class ClassificationHead(head_module.Head):
         if dropout > 0:
             output_node = layers.Dropout(dropout)(output_node)
         output_node = layers.Dense(self.shape[-1])(output_node)
-        if isinstance(self.loss, tf.keras.losses.BinaryCrossentropy):
+        if isinstance(self.loss, keras.losses.BinaryCrossentropy):
             output_node = layers.Activation(activations.sigmoid, name=self.name)(
                 output_node
             )

--- a/autokeras/blocks/heads_test.py
+++ b/autokeras/blocks/heads_test.py
@@ -15,6 +15,7 @@
 import keras_tuner
 import numpy as np
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 
 import autokeras as ak
@@ -63,9 +64,9 @@ def test_multi_label_loss():
     head = head_module.ClassificationHead(
         name="a", multi_label=True, num_classes=8, shape=(8,)
     )
-    input_node = tf.keras.Input(shape=(5,))
+    input_node = keras.Input(shape=(5,))
     output_node = head.build(keras_tuner.HyperParameters(), input_node)
-    model = tf.keras.Model(input_node, output_node)
+    model = keras.Model(input_node, output_node)
     assert model.layers[-1].activation.__name__ == "sigmoid"
     assert head.loss.name == "binary_crossentropy"
 
@@ -94,7 +95,7 @@ def test_clf_head_build_with_zero_dropout_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(5,), dtype=tf.float32),
+        keras.Input(shape=(5,), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -124,7 +125,7 @@ def test_reg_head_build_with_zero_dropout_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(5,), dtype=tf.float32),
+        keras.Input(shape=(5,), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1

--- a/autokeras/blocks/preprocessing.py
+++ b/autokeras/blocks/preprocessing.py
@@ -17,7 +17,7 @@ from typing import Tuple
 from typing import Union
 
 from tensorflow import nest
-from tensorflow.keras.layers.experimental import preprocessing
+from tensorflow.keras import layers
 
 from autokeras import analysers
 from autokeras import keras_layers
@@ -42,7 +42,7 @@ class Normalization(block_module.Block):
 
     def build(self, hp, inputs=None):
         input_node = nest.flatten(inputs)[0]
-        return preprocessing.Normalization(axis=self.axis)(input_node)
+        return layers.Normalization(axis=self.axis)(input_node)
 
     def get_config(self):
         config = super().get_config()
@@ -87,7 +87,7 @@ class TextToIntSequence(block_module.Block):
             output_sequence_length = hp.Choice(
                 "output_sequence_length", [64, 128, 256, 512], default=64
             )
-        output_node = preprocessing.TextVectorization(
+        output_node = layers.TextVectorization(
             max_tokens=self.max_tokens,
             output_mode="int",
             output_sequence_length=output_sequence_length,
@@ -122,7 +122,7 @@ class TextToNgramVector(block_module.Block):
             ngrams = self.ngrams
         else:
             ngrams = hp.Int("ngrams", min_value=1, max_value=2, default=2)
-        return preprocessing.TextVectorization(
+        return layers.TextVectorization(
             max_tokens=self.max_tokens,
             ngrams=ngrams,
             output_mode="tf-idf",
@@ -199,9 +199,9 @@ class ImageAugmentation(block_module.Block):
             height_factor, width_factor = self._get_fraction_value(
                 translation_factor
             )
-            output_node = preprocessing.RandomTranslation(
-                height_factor, width_factor
-            )(output_node)
+            output_node = layers.RandomTranslation(height_factor, width_factor)(
+                output_node
+            )
 
         # Flip
         horizontal_flip = self.horizontal_flip
@@ -219,14 +219,14 @@ class ImageAugmentation(block_module.Block):
         elif not horizontal_flip and vertical_flip:
             flip_mode = "vertical"
         if flip_mode != "":
-            output_node = preprocessing.RandomFlip(mode=flip_mode)(output_node)
+            output_node = layers.RandomFlip(mode=flip_mode)(output_node)
 
         # Rotate
         rotation_factor = self.rotation_factor
         if rotation_factor is None:
             rotation_factor = hp.Choice("rotation_factor", [0.0, 0.1])
         if rotation_factor != 0:
-            output_node = preprocessing.RandomRotation(rotation_factor)(output_node)
+            output_node = layers.RandomRotation(rotation_factor)(output_node)
 
         # Zoom
         zoom_factor = self.zoom_factor
@@ -235,7 +235,7 @@ class ImageAugmentation(block_module.Block):
         if zoom_factor not in [0, (0, 0)]:
             height_factor, width_factor = self._get_fraction_value(zoom_factor)
             # TODO: Add back RandomZoom when it is ready.
-            # output_node = preprocessing.RandomZoom(
+            # output_node = layers.RandomZoom(
             # height_factor, width_factor)(output_node)
 
         # Contrast
@@ -243,7 +243,7 @@ class ImageAugmentation(block_module.Block):
         if contrast_factor is None:
             contrast_factor = hp.Choice("contrast_factor", [0.0, 0.1])
         if contrast_factor not in [0, (0, 0)]:
-            output_node = preprocessing.RandomContrast(contrast_factor)(output_node)
+            output_node = layers.RandomContrast(contrast_factor)(output_node)
 
         return output_node
 

--- a/autokeras/blocks/preprocessing_test.py
+++ b/autokeras/blocks/preprocessing_test.py
@@ -14,6 +14,7 @@
 
 import keras_tuner
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 
 from autokeras import blocks
@@ -25,7 +26,7 @@ def test_augment_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -36,7 +37,7 @@ def test_augment_build_with_translation_factor_range_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -47,7 +48,7 @@ def test_augment_build_with_no_flip_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -58,7 +59,7 @@ def test_augment_build_with_vflip_only_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -69,7 +70,7 @@ def test_augment_build_with_zoom_factor_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -80,7 +81,7 @@ def test_augment_build_with_contrast_factor_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -108,7 +109,7 @@ def test_ngram_build_return_tensor():
     block = blocks.TextToNgramVector()
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(1,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(1,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -118,7 +119,7 @@ def test_ngram_build_with_ngrams_return_tensor():
     block = blocks.TextToNgramVector(ngrams=2)
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(1,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(1,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -146,7 +147,7 @@ def test_int_seq_build_return_tensor():
     block = blocks.TextToIntSequence()
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(1,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(1,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -156,7 +157,7 @@ def test_int_seq_build_with_seq_len_return_tensor():
     block = blocks.TextToIntSequence(output_sequence_length=50)
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(1,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(1,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -186,7 +187,7 @@ def test_cat_to_num_build_return_tensor():
     block.column_types = {"a": "num"}
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(1,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(1,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1

--- a/autokeras/blocks/reduction_test.py
+++ b/autokeras/blocks/reduction_test.py
@@ -14,6 +14,7 @@
 
 import keras_tuner
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 
 from autokeras import blocks
@@ -26,8 +27,8 @@ def test_merge_build_return_tensor():
     outputs = block.build(
         keras_tuner.HyperParameters(),
         [
-            tf.keras.Input(shape=(32,), dtype=tf.float32),
-            tf.keras.Input(shape=(4, 8), dtype=tf.float32),
+            keras.Input(shape=(32,), dtype=tf.float32),
+            keras.Input(shape=(4, 8), dtype=tf.float32),
         ],
     )
 
@@ -39,7 +40,7 @@ def test_merge_single_input_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32,), dtype=tf.float32),
+        keras.Input(shape=(32,), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -51,8 +52,8 @@ def test_merge_inputs_with_same_shape_return_tensor():
     outputs = block.build(
         keras_tuner.HyperParameters(),
         [
-            tf.keras.Input(shape=(32,), dtype=tf.float32),
-            tf.keras.Input(shape=(32,), dtype=tf.float32),
+            keras.Input(shape=(32,), dtype=tf.float32),
+            keras.Input(shape=(32,), dtype=tf.float32),
         ],
     )
 
@@ -80,7 +81,7 @@ def test_temporal_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 10), dtype=tf.float32),
+        keras.Input(shape=(32, 10), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -91,7 +92,7 @@ def test_temporal_global_max_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 10), dtype=tf.float32),
+        keras.Input(shape=(32, 10), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -102,7 +103,7 @@ def test_temporal_global_avg_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 10), dtype=tf.float32),
+        keras.Input(shape=(32, 10), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -110,7 +111,7 @@ def test_temporal_global_avg_return_tensor():
 
 def test_reduction_2d_tensor_return_input_node():
     block = blocks.TemporalReduction()
-    input_node = tf.keras.Input(shape=(32,), dtype=tf.float32)
+    input_node = keras.Input(shape=(32,), dtype=tf.float32)
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
@@ -144,7 +145,7 @@ def test_spatial_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1

--- a/autokeras/blocks/wrapper_test.py
+++ b/autokeras/blocks/wrapper_test.py
@@ -14,6 +14,7 @@
 
 import keras_tuner
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 
 from autokeras import analysers
@@ -26,7 +27,7 @@ def test_image_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -37,7 +38,7 @@ def test_image_block_xception_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -48,7 +49,7 @@ def test_image_block_normalize_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -59,7 +60,7 @@ def test_image_block_augment_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 32, 3), dtype=tf.float32),
+        keras.Input(shape=(32, 32, 3), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -87,7 +88,7 @@ def test_text_build_return_tensor():
     block = blocks.TextBlock()
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(1,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(1,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -97,7 +98,7 @@ def test_text_block_ngram_return_tensor():
     block = blocks.TextBlock(block_type="ngram")
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(1,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(1,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -107,7 +108,7 @@ def test_text_block_transformer_return_tensor():
     block = blocks.TextBlock(block_type="transformer")
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(1,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(1,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -137,7 +138,7 @@ def test_structured_build_return_tensor():
     block.column_types = {"0": analysers.NUMERICAL, "1": analysers.NUMERICAL}
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(2,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(2,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -149,7 +150,7 @@ def test_structured_block_normalize_return_tensor():
     block.column_types = {"0": analysers.NUMERICAL, "1": analysers.NUMERICAL}
 
     outputs = block.build(
-        keras_tuner.HyperParameters(), tf.keras.Input(shape=(2,), dtype=tf.string)
+        keras_tuner.HyperParameters(), keras.Input(shape=(2,), dtype=tf.string)
     )
 
     assert len(nest.flatten(outputs)) == 1
@@ -162,7 +163,7 @@ def test_structured_block_search_normalize_return_tensor():
     hp = keras_tuner.HyperParameters()
     hp.values["a/" + blocks.wrapper.NORMALIZE] = True
 
-    outputs = block.build(hp, tf.keras.Input(shape=(2,), dtype=tf.string))
+    outputs = block.build(hp, keras.Input(shape=(2,), dtype=tf.string))
 
     assert len(nest.flatten(outputs)) == 1
 
@@ -192,7 +193,7 @@ def test_timeseries_build_return_tensor():
 
     outputs = block.build(
         keras_tuner.HyperParameters(),
-        tf.keras.Input(shape=(32, 2), dtype=tf.float32),
+        keras.Input(shape=(32, 2), dtype=tf.float32),
     )
 
     assert len(nest.flatten(outputs)) == 1

--- a/autokeras/conftest.py
+++ b/autokeras/conftest.py
@@ -15,14 +15,14 @@
 import shutil
 
 import pytest
-import tensorflow as tf
+from tensorflow import keras
 
 
 @pytest.fixture(autouse=True)
 def clear_session():
-    tf.keras.backend.clear_session()
+    keras.backend.clear_session()
     yield
-    tf.keras.backend.clear_session()
+    keras.backend.clear_session()
 
 
 @pytest.fixture(autouse=True)

--- a/autokeras/engine/head.py
+++ b/autokeras/engine/head.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import Optional
 
-import tensorflow as tf
+from tensorflow import keras
 
 from autokeras.engine import io_hypermodel
 from autokeras.utils import types
@@ -25,7 +25,7 @@ def serialize_metrics(metrics):
         if isinstance(metric, str):
             serialized.append([metric])
         else:
-            serialized.append(tf.keras.metrics.serialize(metric))
+            serialized.append(keras.metrics.serialize(metric))
     return serialized
 
 
@@ -35,20 +35,20 @@ def deserialize_metrics(metrics):
         if isinstance(metric, list):
             deserialized.append(metric[0])
         else:
-            deserialized.append(tf.keras.metrics.deserialize(metric))
+            deserialized.append(keras.metrics.deserialize(metric))
     return deserialized
 
 
 def serialize_loss(loss):
     if isinstance(loss, str):
         return [loss]
-    return tf.keras.losses.serialize(loss)
+    return keras.losses.serialize(loss)
 
 
 def deserialize_loss(loss):
     if isinstance(loss, list):
         return loss[0]
-    return tf.keras.losses.deserialize(loss)
+    return keras.losses.deserialize(loss)
 
 
 class Head(io_hypermodel.IOHyperModel):

--- a/autokeras/engine/named_hypermodel.py
+++ b/autokeras/engine/named_hypermodel.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import keras_tuner
-import tensorflow as tf
+from tensorflow import keras
 
 from autokeras.engine import serializable
 from autokeras.utils import utils
@@ -30,7 +30,7 @@ class NamedHyperModel(keras_tuner.HyperModel, serializable.Serializable):
     def __init__(self, name: str = None, **kwargs):
         if not name:
             prefix = self.__class__.__name__
-            name = prefix + "_" + str(tf.keras.backend.get_uid(prefix))
+            name = prefix + "_" + str(keras.backend.get_uid(prefix))
             name = utils.to_snake_case(name)
         super().__init__(name=name, **kwargs)
 

--- a/autokeras/engine/tuner.py
+++ b/autokeras/engine/tuner.py
@@ -17,7 +17,7 @@ import copy
 import os
 
 import keras_tuner
-import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 from tensorflow.keras import callbacks as tf_callbacks
 from tensorflow.keras.layers.experimental import preprocessing
@@ -60,7 +60,7 @@ class AutoTuner(keras_tuner.engine.tuner.Tuner):
 
     def get_best_model(self):
         with keras_tuner.engine.tuner.maybe_distribute(self.distribution_strategy):
-            model = tf.keras.models.load_model(self.best_model_path)
+            model = keras.models.load_model(self.best_model_path)
         return model
 
     def get_best_pipeline(self):
@@ -116,7 +116,7 @@ class AutoTuner(keras_tuner.engine.tuner.Tuner):
             output_layers = []
             tensor = nest.flatten(tensor)[0]
             for layer in model.layers:
-                if isinstance(layer, tf.keras.layers.InputLayer):
+                if isinstance(layer, keras.layers.InputLayer):
                     continue
                 input_node = nest.flatten(layer.input)[0]
                 if input_node is tensor:

--- a/autokeras/engine/tuner_test.py
+++ b/autokeras/engine/tuner_test.py
@@ -16,6 +16,7 @@ from unittest import mock
 
 import numpy as np
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow.keras.layers.experimental import preprocessing
 
 import autokeras as ak
@@ -29,7 +30,7 @@ def called_with_early_stopping(func):
     callbacks = func.call_args_list[0][1]["callbacks"]
     return any(
         [
-            isinstance(callback, tf.keras.callbacks.EarlyStopping)
+            isinstance(callback, keras.callbacks.EarlyStopping)
             for callback in callbacks
         ]
     )
@@ -148,8 +149,8 @@ def test_preprocessing_adapt_with_cat_to_int_and_norm():
     x = np.array([["a", 5], ["b", 6]]).astype(np.unicode)
     y = np.array([[1, 2], [3, 4]]).astype(np.unicode)
     dataset = tf.data.Dataset.from_tensor_slices((x, y)).batch(32)
-    model = tf.keras.models.Sequential()
-    model.add(tf.keras.Input(shape=(2,), dtype=tf.string))
+    model = keras.models.Sequential()
+    model.add(keras.Input(shape=(2,), dtype=tf.string))
     model.add(keras_layers.MultiCategoryEncoding(["int", "none"]))
     model.add(preprocessing.Normalization(axis=-1))
 
@@ -166,11 +167,11 @@ def test_preprocessing_adapt_with_text_vec():
     y_train = np.random.randint(0, 2, (100,))
     dataset = tf.data.Dataset.from_tensor_slices((x_train, y_train)).batch(32)
     layer1 = MockLayer(max_tokens=5000, output_mode="int", output_sequence_length=40)
-    model = tf.keras.models.Sequential()
-    model.add(tf.keras.Input(shape=(1,), dtype=tf.string))
+    model = keras.models.Sequential()
+    model.add(keras.Input(shape=(1,), dtype=tf.string))
     model.add(layer1)
-    model.add(tf.keras.layers.Embedding(50001, 10))
-    model.add(tf.keras.layers.Dense(1))
+    model.add(keras.layers.Embedding(50001, 10))
+    model.add(keras.layers.Dense(1))
 
     tuner_module.AutoTuner.adapt(model, dataset)
 
@@ -178,11 +179,9 @@ def test_preprocessing_adapt_with_text_vec():
 
 
 def test_adapt_with_model_with_preprocessing_layer_only():
-    input_node = tf.keras.Input(shape=(10,))
-    output_node = tf.keras.layers.experimental.preprocessing.Normalization()(
-        input_node
-    )
-    model = tf.keras.Model(input_node, output_node)
+    input_node = keras.Input(shape=(10,))
+    output_node = keras.layers.experimental.preprocessing.Normalization()(input_node)
+    model = keras.Model(input_node, output_node)
     greedy.Greedy.adapt(
         model,
         tf.data.Dataset.from_tensor_slices(
@@ -195,7 +194,7 @@ def test_build_block_in_blocks_with_same_name(tmp_path):
     class Block1(ak.Block):
         def build(self, hp, inputs):
             hp.Boolean("a")
-            return tf.keras.layers.Dense(3)(tf.nest.flatten(inputs)[0])
+            return keras.layers.Dense(3)(tf.nest.flatten(inputs)[0])
 
     class Block2(ak.Block):
         def build(self, hp, inputs):

--- a/autokeras/graph.py
+++ b/autokeras/graph.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import keras_tuner
-import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 
 from autokeras import blocks as blocks_module
@@ -47,7 +47,7 @@ COMPILE_FUNCTIONS = {
 def load_graph(filepath, custom_objects=None):
     if custom_objects is None:
         custom_objects = {}
-    with tf.keras.utils.custom_object_scope(custom_objects):
+    with keras.utils.custom_object_scope(custom_objects):
         return Graph.from_config(io_utils.load_json(filepath))
 
 
@@ -251,7 +251,7 @@ class Graph(keras_tuner.HyperModel, serializable.Serializable):
             outputs = nest.flatten(outputs)
             for output_node, real_output_node in zip(block.outputs, outputs):
                 keras_nodes[self._node_to_id[output_node]] = real_output_node
-        model = tf.keras.Model(
+        model = keras.Model(
             keras_input_nodes,
             [
                 keras_nodes[self._node_to_id[output_node]]
@@ -290,9 +290,9 @@ class Graph(keras_tuner.HyperModel, serializable.Serializable):
         )
 
         if optimizer_name == "adam":
-            optimizer = tf.keras.optimizers.Adam(learning_rate=learning_rate)
+            optimizer = keras.optimizers.Adam(learning_rate=learning_rate)
         elif optimizer_name == "sgd":
-            optimizer = tf.keras.optimizers.SGD(learning_rate=learning_rate)
+            optimizer = keras.optimizers.SGD(learning_rate=learning_rate)
         elif optimizer_name == "adam_weight_decay":
             steps_per_epoch = int(self.num_samples / self.batch_size)
             num_train_steps = steps_per_epoch * self.epochs
@@ -300,7 +300,7 @@ class Graph(keras_tuner.HyperModel, serializable.Serializable):
                 self.epochs * self.num_samples * 0.1 / self.batch_size
             )
 
-            lr_schedule = tf.keras.optimizers.schedules.PolynomialDecay(
+            lr_schedule = keras.optimizers.schedules.PolynomialDecay(
                 initial_learning_rate=learning_rate,
                 decay_steps=num_train_steps,
                 end_learning_rate=0.0,

--- a/autokeras/hyper_preprocessors.py
+++ b/autokeras/hyper_preprocessors.py
@@ -11,18 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import tensorflow as tf
+from tensorflow import keras
 
 from autokeras import preprocessors
 from autokeras.engine import hyper_preprocessor
 
 
 def serialize(encoder):
-    return tf.keras.utils.serialize_keras_object(encoder)
+    return keras.utils.serialize_keras_object(encoder)
 
 
 def deserialize(config, custom_objects=None):
-    return tf.keras.utils.deserialize_keras_object(
+    return keras.utils.deserialize_keras_object(
         config,
         module_objects=globals(),
         custom_objects=custom_objects,

--- a/autokeras/integration_tests/task_api_test.py
+++ b/autokeras/integration_tests/task_api_test.py
@@ -15,6 +15,7 @@
 import numpy as np
 import pandas as pd
 import tensorflow as tf
+from tensorflow import keras
 
 import autokeras as ak
 from autokeras import test_utils
@@ -33,7 +34,7 @@ def test_image_classifier(tmp_path):
     keras_model = clf.export_model()
     clf.evaluate(train_x, train_y)
     assert clf.predict(train_x).shape == (len(train_x), 10)
-    assert isinstance(keras_model, tf.keras.Model)
+    assert isinstance(keras_model, keras.Model)
 
 
 def test_image_regressor(tmp_path):
@@ -135,4 +136,4 @@ def test_timeseries_forecaster(tmp_path):
     assert clf.fit_and_predict(
         train_x, train_y, epochs=1, validation_split=0.2
     ).shape == (predict_until - predict_from + 1, 1)
-    assert isinstance(keras_model, tf.keras.Model)
+    assert isinstance(keras_model, keras.Model)

--- a/autokeras/keras_layers_test.py
+++ b/autokeras/keras_layers_test.py
@@ -16,6 +16,7 @@ import os
 
 import numpy as np
 import tensorflow as tf
+from tensorflow import keras
 
 from autokeras import keras_layers as layer_module
 
@@ -47,9 +48,9 @@ def test_model_save_load_output_same(tmp_path):
     )
     layer.adapt(tf.data.Dataset.from_tensor_slices(x_train).batch(32))
 
-    model = tf.keras.Sequential([tf.keras.Input(shape=(3,), dtype=tf.string), layer])
+    model = keras.Sequential([keras.Input(shape=(3,), dtype=tf.string), layer])
     model.save(os.path.join(tmp_path, "model"))
-    model2 = tf.keras.models.load_model(os.path.join(tmp_path, "model"))
+    model2 = keras.models.load_model(os.path.join(tmp_path, "model"))
 
     assert np.array_equal(model.predict(x_train), model2.predict(x_train))
 
@@ -107,11 +108,11 @@ def test_bert_tokenizer_save_and_load(tmp_path):
     max_sequence_length = 8
     layer = layer_module.BertTokenizer(max_sequence_length=max_sequence_length)
 
-    input_node = tf.keras.Input(shape=(1,), dtype=tf.string)
+    input_node = keras.Input(shape=(1,), dtype=tf.string)
     output_node = layer(input_node)
-    model = tf.keras.Model(input_node, output_node)
+    model = keras.Model(input_node, output_node)
     model.save(os.path.join(tmp_path, "model"))
-    model2 = tf.keras.models.load_model(os.path.join(tmp_path, "model"))
+    model2 = keras.models.load_model(os.path.join(tmp_path, "model"))
 
     assert np.array_equal(model.predict(x_train), model2.predict(x_train))
 
@@ -119,18 +120,18 @@ def test_bert_tokenizer_save_and_load(tmp_path):
 def test_transformer_encoder_save_and_load(tmp_path):
     layer = layer_module.BertEncoder()
     inputs = [
-        tf.keras.Input(shape=(500,), dtype=tf.int64),
-        tf.keras.Input(shape=(500,), dtype=tf.int64),
-        tf.keras.Input(shape=(500,), dtype=tf.int64),
+        keras.Input(shape=(500,), dtype=tf.int64),
+        keras.Input(shape=(500,), dtype=tf.int64),
+        keras.Input(shape=(500,), dtype=tf.int64),
     ]
-    model = tf.keras.Model(inputs, layer(inputs))
+    model = keras.Model(inputs, layer(inputs))
     model.save(os.path.join(tmp_path, "model"))
-    tf.keras.models.load_model(os.path.join(tmp_path, "model"))
+    keras.models.load_model(os.path.join(tmp_path, "model"))
 
 
 def test_adam_weight_decay(tmp_path):
-    model = tf.keras.Sequential([tf.keras.layers.Dense(10, input_shape=(10,))])
-    lr_schedule = tf.keras.optimizers.schedules.PolynomialDecay(
+    model = keras.Sequential([keras.layers.Dense(10, input_shape=(10,))])
+    lr_schedule = keras.optimizers.schedules.PolynomialDecay(
         initial_learning_rate=0.1,
         decay_steps=100,
         end_learning_rate=0.0,

--- a/autokeras/nodes.py
+++ b/autokeras/nodes.py
@@ -17,6 +17,7 @@ from typing import List
 from typing import Optional
 
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 
 from autokeras import adapters
@@ -30,11 +31,11 @@ from autokeras.engine import node as node_module
 
 
 def serialize(obj):
-    return tf.keras.utils.serialize_keras_object(obj)
+    return keras.utils.serialize_keras_object(obj)
 
 
 def deserialize(config, custom_objects=None):
-    return tf.keras.utils.deserialize_keras_object(
+    return keras.utils.deserialize_keras_object(
         config,
         module_objects=globals(),
         custom_objects=custom_objects,
@@ -56,7 +57,7 @@ class Input(node_module.Node, io_hypermodel.IOHyperModel):
         super().__init__(name=name, **kwargs)
 
     def build_node(self, hp):
-        return tf.keras.Input(shape=self.shape, dtype=self.dtype)
+        return keras.Input(shape=self.shape, dtype=self.dtype)
 
     def build(self, hp, inputs=None):
         input_node = nest.flatten(inputs)[0]
@@ -123,7 +124,7 @@ class TextInput(Input):
         super().__init__(name=name, **kwargs)
 
     def build_node(self, hp):
-        return tf.keras.Input(shape=self.shape, dtype=tf.string)
+        return keras.Input(shape=self.shape, dtype=tf.string)
 
     def build(self, hp, inputs=None):
         output_node = nest.flatten(inputs)[0]

--- a/autokeras/pipeline.py
+++ b/autokeras/pipeline.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow import nest
 
 from autokeras import preprocessors as preprocessors_module
@@ -72,7 +73,7 @@ def load_pipeline(filepath, custom_objects=None):
     """Load a Pipeline instance from disk."""
     if custom_objects is None:
         custom_objects = {}
-    with tf.keras.utils.custom_object_scope(custom_objects):
+    with keras.utils.custom_object_scope(custom_objects):
         return Pipeline.from_config(io_utils.load_json(filepath))
 
 

--- a/autokeras/preprocessors/__init__.py
+++ b/autokeras/preprocessors/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import tensorflow as tf
+from tensorflow import keras
 
 from autokeras.preprocessors.common import AddOneDimension
 from autokeras.preprocessors.common import CastToInt32
@@ -26,11 +27,11 @@ from autokeras.preprocessors.postprocessors import SoftmaxPostprocessor
 
 
 def serialize(preprocessor):
-    return tf.keras.utils.serialize_keras_object(preprocessor)
+    return keras.utils.serialize_keras_object(preprocessor)
 
 
 def deserialize(config, custom_objects=None):
-    return tf.keras.utils.deserialize_keras_object(
+    return keras.utils.deserialize_keras_object(
         config,
         module_objects=globals(),
         custom_objects=custom_objects,

--- a/autokeras/tasks/image.py
+++ b/autokeras/tasks/image.py
@@ -20,6 +20,7 @@ from typing import Type
 from typing import Union
 
 import tensorflow as tf
+from tensorflow import keras
 
 from autokeras import auto_model
 from autokeras import blocks
@@ -109,7 +110,7 @@ class ImageClassifier(SupervisedImagePipeline):
         x: Optional[types.DatasetType] = None,
         y: Optional[types.DatasetType] = None,
         epochs: Optional[int] = None,
-        callbacks: Optional[List[tf.keras.callbacks.Callback]] = None,
+        callbacks: Optional[List[keras.callbacks.Callback]] = None,
         validation_split: Optional[float] = 0.2,
         validation_data: Union[
             tf.data.Dataset, Tuple[types.DatasetType, types.DatasetType], None
@@ -241,7 +242,7 @@ class ImageRegressor(SupervisedImagePipeline):
         x: Optional[types.DatasetType] = None,
         y: Optional[types.DatasetType] = None,
         epochs: Optional[int] = None,
-        callbacks: Optional[List[tf.keras.callbacks.Callback]] = None,
+        callbacks: Optional[List[keras.callbacks.Callback]] = None,
         validation_split: Optional[float] = 0.2,
         validation_data: Union[
             types.DatasetType, Tuple[types.DatasetType], None
@@ -371,7 +372,7 @@ class ImageSegmenter(SupervisedImagePipeline):
         x: Optional[types.DatasetType] = None,
         y: Optional[types.DatasetType] = None,
         epochs: Optional[int] = None,
-        callbacks: Optional[List[tf.keras.callbacks.Callback]] = None,
+        callbacks: Optional[List[keras.callbacks.Callback]] = None,
         validation_split: Optional[float] = 0.2,
         validation_data: Union[
             types.DatasetType, Tuple[types.DatasetType], None
@@ -492,7 +493,7 @@ class ImageObjectDetector(SupervisedImagePipeline):
         x: Optional[types.DatasetType] = None,
         y: Optional[types.DatasetType] = None,
         epochs: Optional[int] = None,
-        callbacks: Optional[List[tf.keras.callbacks.Callback]] = None,
+        callbacks: Optional[List[keras.callbacks.Callback]] = None,
         validation_split: Optional[float] = 0.2,
         validation_data: Union[
             tf.data.Dataset, Tuple[types.DatasetType, types.DatasetType], None

--- a/autokeras/test_utils.py
+++ b/autokeras/test_utils.py
@@ -17,6 +17,7 @@ import os
 
 import numpy as np
 import tensorflow as tf
+from tensorflow import keras
 
 import autokeras as ak
 
@@ -46,10 +47,10 @@ COLUMN_TYPES = {
 TRAIN_DATA_URL = "https://storage.googleapis.com/tf-datasets/titanic/train.csv"
 TEST_DATA_URL = "https://storage.googleapis.com/tf-datasets/titanic/eval.csv"
 
-TRAIN_CSV_PATH = tf.keras.utils.get_file(
+TRAIN_CSV_PATH = keras.utils.get_file(
     fname=os.path.basename(TRAIN_DATA_URL), origin=TRAIN_DATA_URL
 )
-TEST_CSV_PATH = tf.keras.utils.get_file(
+TEST_CSV_PATH = keras.utils.get_file(
     fname=os.path.basename(TEST_DATA_URL), origin=TEST_DATA_URL
 )
 
@@ -68,7 +69,7 @@ def generate_data(num_instances=100, shape=(32, 32, 3), dtype="np"):
 def generate_one_hot_labels(num_instances=100, num_classes=10, dtype="np"):
     np.random.seed(SEED)
     labels = np.random.randint(num_classes, size=num_instances)
-    data = tf.keras.utils.to_categorical(labels)
+    data = keras.utils.to_categorical(labels)
     if dtype == "np":
         return data
     if dtype == "dataset":
@@ -109,7 +110,7 @@ def generate_data_with_categorical(
 
 
 def build_graph():
-    tf.keras.backend.clear_session()
+    keras.backend.clear_session()
     image_input = ak.ImageInput(shape=(32, 32, 3))
     image_input.batch_size = 32
     image_input.num_samples = 1000

--- a/autokeras/tuners/greedy_test.py
+++ b/autokeras/tuners/greedy_test.py
@@ -15,7 +15,7 @@
 from unittest import mock
 
 import keras_tuner
-import tensorflow as tf
+from tensorflow import keras
 
 import autokeras as ak
 from autokeras import test_utils
@@ -51,7 +51,7 @@ def test_greedy_oracle_populate_different_values(get_best_trials):
 @mock.patch("autokeras.tuners.greedy.GreedyOracle.get_best_trials")
 def test_greedy_oracle_populate_doesnt_crash_with_init_hps(get_best_trials):
     hp = keras_tuner.HyperParameters()
-    tf.keras.backend.clear_session()
+    keras.backend.clear_session()
     input_node = ak.ImageInput(shape=(32, 32, 3))
     input_node.batch_size = 32
     input_node.num_samples = 1000
@@ -72,7 +72,7 @@ def test_greedy_oracle_populate_doesnt_crash_with_init_hps(get_best_trials):
     get_best_trials.return_value = [trial]
 
     for i in range(10):
-        tf.keras.backend.clear_session()
+        keras.backend.clear_session()
         values = oracle.populate_space("a")["values"]
         hp = oracle.hyperparameters.copy()
         hp.values = values

--- a/autokeras/utils/io_utils_test.py
+++ b/autokeras/utils/io_utils_test.py
@@ -17,13 +17,14 @@ import shutil
 
 import pytest
 import tensorflow as tf
+from tensorflow import keras
 
 from autokeras import test_utils
 from autokeras.utils import io_utils
 
 IMG_DATA_DIR = os.path.join(
     os.path.dirname(
-        tf.keras.utils.get_file(
+        keras.utils.get_file(
             origin="https://storage.googleapis.com/"
             + "download.tensorflow.org/example_images/flower_photos.tgz",
             fname="image_data",
@@ -37,7 +38,7 @@ IMG_DATA_DIR = os.path.join(
 def test_load_imdb_dataset():
     data_dir = os.path.join(
         os.path.dirname(
-            tf.keras.utils.get_file(
+            keras.utils.get_file(
                 fname="text_data",
                 origin="http://ai.stanford.edu/"
                 + "~amaas/data/sentiment/aclImdb_v1.tar.gz",

--- a/autokeras/utils/layer_utils.py
+++ b/autokeras/utils/layer_utils.py
@@ -12,42 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+from tensorflow.keras import layers
 
 
 def get_global_average_pooling(shape):
     return [
-        tf.keras.layers.GlobalAveragePooling1D,
-        tf.keras.layers.GlobalAveragePooling2D,
-        tf.keras.layers.GlobalAveragePooling3D,
+        layers.GlobalAveragePooling1D,
+        layers.GlobalAveragePooling2D,
+        layers.GlobalAveragePooling3D,
     ][len(shape) - 3]
 
 
 def get_global_max_pooling(shape):
     return [
-        tf.keras.layers.GlobalMaxPool1D,
-        tf.keras.layers.GlobalMaxPool2D,
-        tf.keras.layers.GlobalMaxPool3D,
+        layers.GlobalMaxPool1D,
+        layers.GlobalMaxPool2D,
+        layers.GlobalMaxPool3D,
     ][len(shape) - 3]
 
 
 def get_max_pooling(shape):
     return [
-        tf.keras.layers.MaxPool1D,
-        tf.keras.layers.MaxPool2D,
-        tf.keras.layers.MaxPool3D,
+        layers.MaxPool1D,
+        layers.MaxPool2D,
+        layers.MaxPool3D,
     ][len(shape) - 3]
 
 
 def get_conv(shape):
-    return [tf.keras.layers.Conv1D, tf.keras.layers.Conv2D, tf.keras.layers.Conv3D][
-        len(shape) - 3
-    ]
+    return [layers.Conv1D, layers.Conv2D, layers.Conv3D][len(shape) - 3]
 
 
 def get_sep_conv(shape):
     return [
-        tf.keras.layers.SeparableConv1D,
-        tf.keras.layers.SeparableConv2D,
-        tf.keras.layers.Conv3D,
+        layers.SeparableConv1D,
+        layers.SeparableConv2D,
+        layers.Conv3D,
     ][len(shape) - 3]


### PR DESCRIPTION
Re-organize the imports to follow the best practices for keras projects.
Use `from tensorflow import keras` and `from tensorflow.keras import layers`.
