### PR TITLE
Update ImageAugmentation translation_factor hyperparameter to have a range

### DIFF
--- a/autokeras/blocks/preprocessing.py
+++ b/autokeras/blocks/preprocessing.py
@@ -171,7 +171,7 @@ class ImageAugmentation(block_module.Block):
         translation_factor: Optional[Union[float, Tuple[float, float]]] = None,
         vertical_flip: Optional[bool] = None,
         horizontal_flip: Optional[bool] = None,
-        rotation_factor: Optional[float] = None,
+        rotation_factor: Optional[Union[float, hyperparameters.Choice]] = None,
         zoom_factor: Optional[Union[float, Tuple[float, float]]] = None,
         contrast_factor: Optional[Union[float, Tuple[float, float]]] = None,
         **kwargs

--- a/autokeras/blocks/preprocessing.py
+++ b/autokeras/blocks/preprocessing.py
@@ -143,8 +143,9 @@ class ImageAugmentation(block_module.Block):
     # Arguments
         translation_factor: A positive float represented as fraction value, or a
             tuple of 2 representing fraction for translation vertically and
-            horizontally.  For instance, `translation_factor=0.2` result in a random
-            translation factor within 20% of the width and height.
+            horizontally, or a kerastuner.engine.hyperparameters.Choice range
+            of positive floats. For instance, `translation_factor=0.2` result
+            in a random translation factor within 20% of the width and height.
             If left unspecified, it will be tuned automatically.
         vertical_flip: Boolean. Whether to flip the image vertically.
             If left unspecified, it will be tuned automatically.
@@ -168,7 +169,9 @@ class ImageAugmentation(block_module.Block):
 
     def __init__(
         self,
-        translation_factor: Optional[Union[float, Tuple[float, float]]] = None,
+        translation_factor: Optional[
+            Union[float, Tuple[float, float], hyperparameters.Choice]
+        ] = None,
         vertical_flip: Optional[bool] = None,
         horizontal_flip: Optional[bool] = None,
         rotation_factor: Optional[Union[float, hyperparameters.Choice]] = None,
@@ -177,7 +180,11 @@ class ImageAugmentation(block_module.Block):
         **kwargs
     ):
         super().__init__(**kwargs)
-        self.translation_factor = translation_factor
+        self.translation_factor = utils.get_hyperparameter(
+            translation_factor,
+            hyperparameters.Choice("translation_factor", [0.0, 0.1]),
+            Union[float, Tuple[float, float]],
+        )
         self.horizontal_flip = horizontal_flip
         self.vertical_flip = vertical_flip
         self.rotation_factor = utils.get_hyperparameter(
@@ -199,9 +206,7 @@ class ImageAugmentation(block_module.Block):
         output_node = input_node
 
         # Translate
-        translation_factor = self.translation_factor
-        if translation_factor is None:
-            translation_factor = hp.Choice("translation_factor", [0.0, 0.1])
+        translation_factor = utils.add_to_hp(self.translation_factor, hp)
         if translation_factor not in [0, (0, 0)]:
             height_factor, width_factor = self._get_fraction_value(
                 translation_factor
@@ -256,7 +261,9 @@ class ImageAugmentation(block_module.Block):
         config = super().get_config()
         config.update(
             {
-                "translation_factor": self.translation_factor,
+                "translation_factor": hyperparameters.serialize(
+                    self.translation_factor
+                ),
                 "horizontal_flip": self.horizontal_flip,
                 "vertical_flip": self.vertical_flip,
                 "rotation_factor": hyperparameters.serialize(self.rotation_factor),

--- a/autokeras/blocks/preprocessing.py
+++ b/autokeras/blocks/preprocessing.py
@@ -148,7 +148,8 @@ class ImageAugmentation(block_module.Block):
             If left unspecified, it will be tuned automatically.
         horizontal_flip: Boolean. Whether to flip the image horizontally.
             If left unspecified, it will be tuned automatically.
-        rotation_factor: Float. A positive float represented as fraction of 2pi
+        rotation_factor: Float or kerastuner.engine.hyperparameters.Choice range
+            between [0, 1]. A positive float represented as fraction of 2pi
             upper bound for rotating clockwise and counter-clockwise. When
             represented as a single float, lower = upper.
             If left unspecified, it will be tuned automatically.


### PR DESCRIPTION
### Which issue(s) does this Pull Request fix?
Partial resolve for #1420

### Details of the Pull Request
Added functionality for the user to specify a `hyperparameters.Choice` object for the `translation_factor` of `ImageAugmentation`. 

Note: although `translation_factor` accepts either a float or a tuple of floats, hyperparameters.Choice does not support tuples and is thus limited to a range of single floats.