### PR TITLE
Fixed: #1722 Run out of memory

### DIFF
--- a/autokeras/utils/utils.py
+++ b/autokeras/utils/utils.py
@@ -94,15 +94,20 @@ def fit_with_adaptive_batch_size(model, batch_size, **fit_kwargs):
 def run_with_adaptive_batch_size(batch_size, func, **fit_kwargs):
     x = fit_kwargs.pop("x")
     validation_data = None
+    history = None
     if "validation_data" in fit_kwargs:
         validation_data = fit_kwargs.pop("validation_data")
     while batch_size > 0:
         try:
             history = func(x=x, validation_data=validation_data, **fit_kwargs)
             break
-        except tf.errors.ResourceExhaustedError as e:
+        except tf.errors.ResourceExhaustedError:
             if batch_size == 1:
-                raise e
+                print(
+                    "Not enough memory, reduced batch size is already set to 1. "
+                    "Current model will be skipped."
+                )
+                break
             batch_size //= 2
             print(
                 "Not enough memory, reduce batch size to {batch_size}.".format(

--- a/autokeras/utils/utils_test.py
+++ b/autokeras/utils/utils_test.py
@@ -53,19 +53,20 @@ def test_check_kt_version_error():
     )
 
 
-def test_run_with_adaptive_batch_size_raise_error():
+def test_run_with_adaptive_batch_size_raise_error(capfd):
     def func(**kwargs):
         raise tf.errors.ResourceExhaustedError(0, "", None)
 
-    with pytest.raises(tf.errors.ResourceExhaustedError):
-        utils.run_with_adaptive_batch_size(
-            batch_size=64,
-            func=func,
-            x=tf.data.Dataset.from_tensor_slices(np.random.rand(100, 1)).batch(64),
-            validation_data=tf.data.Dataset.from_tensor_slices(
-                np.random.rand(100, 1)
-            ).batch(64),
-        )
+    utils.run_with_adaptive_batch_size(
+        batch_size=64,
+        func=func,
+        x=tf.data.Dataset.from_tensor_slices(np.random.rand(100, 1)).batch(64),
+        validation_data=tf.data.Dataset.from_tensor_slices(
+            np.random.rand(100, 1)
+        ).batch(64),
+    )
+    std, _ = capfd.readouterr()
+    assert "Not enough memory" in std
 
 
 def test_get_hyperparameter_with_none_return_hp():


### PR DESCRIPTION
Update utils.py and test by using `break` instead of `raise`

<!-- STEP 1: Give the pull request a meaningful title. -->
### Which issue(s) does this Pull Request fix?
<!-- STEP 2: Replace the "000" with the issue ID this pull request resolves. -->
resolves #1722

### Details of the Pull Request

According to discussion #1721, the`raise` will be replaced by `break` for running _out of memory_ in the case of `batch_size==1`
.