### PR TITLE
Fixed: #1494 Check optimizer and learning rate settings

### DIFF
--- a/autokeras/graph.py
+++ b/autokeras/graph.py
@@ -279,20 +279,33 @@ class Graph(keras_tuner.HyperModel, serializable.Serializable):
 
     def _compile_keras_model(self, hp, model):
         # Specify hyperparameters from compile(...)
-        optimizer_name = hp.Choice(
-            "optimizer",
-            ["adam", "sgd", "adam_weight_decay"],
-            default="adam",
-        )
+        # check if optimizer is set before applying default optimizer settings.
+        if "optimizer" in hp.values.keys():
+            optimizer_name = hp.get("optimizer")
+        else:
+            optimizer_name = hp.Choice(
+                "optimizer",
+                ["adam", "sgd", "adam_weight_decay"],
+                default="adam",
+            )
+            
         # TODO: add adadelta optimizer when it can optimize embedding layer on GPU.
-        learning_rate = hp.Choice(
-            "learning_rate", [1e-1, 1e-2, 1e-3, 1e-4, 2e-5, 1e-5], default=1e-3
-        )
+        # check if learning rate is set before applying default learning rate settings.
+        if "learning_rate" in hp.values.keys():
+            learning_rate = hp.get("learning_rate")
+        else:
+            learning_rate = hp.Choice(
+                "learning_rate", [1e-1, 1e-2, 1e-3, 1e-4, 2e-5, 1e-5], default=1e-3
+            )
 
         if optimizer_name == "adam":
             optimizer = keras.optimizers.Adam(learning_rate=learning_rate)
         elif optimizer_name == "sgd":
             optimizer = keras.optimizers.SGD(learning_rate=learning_rate)
+        elif optimizer_name == "rmsprop":
+            optimizer = keras.optimizers.RMSprop(learning_rate=learning_rate)
+        elif optimizer_name == "adadelta":
+            optimizer = keras.optimizers.Adadelta(learning_rate=learning_rate)
         elif optimizer_name == "adam_weight_decay":
             steps_per_epoch = int(self.num_samples / self.batch_size)
             num_train_steps = steps_per_epoch * self.epochs

--- a/autokeras/graph.py
+++ b/autokeras/graph.py
@@ -295,7 +295,8 @@ class Graph(keras_tuner.HyperModel, serializable.Serializable):
             learning_rate = hp.get("learning_rate")
         else:
             learning_rate = hp.Choice(
-                "learning_rate", [1e-1, 1e-2, 1e-3, 1e-4, 2e-5, 1e-5], default=1e-3
+                "learning_rate", [1e-1, 1e-2, 1e-3, 1e-4, 2e-5, 1e-5], 
+                default=1e-3,
             )
 
         if optimizer_name == "adam":


### PR DESCRIPTION
<!-- STEP 1: Give the pull request a meaningful title. -->
### Which issue(s) does this Pull Request fix?
<!-- STEP 2: Replace the "000" with the issue ID this pull request resolves. -->
Partial resolves #1494

### Details of the Pull Request
<!-- STEP 3: Add details/comments on the pull request. -->
In fact, this fix is more likely a resolving for #1480. (with implicit insertion of rmsprop and adadelta optimizers with default settings.)

This pull request is for checking if there already exist hyperparameter settings for optimizer and learning rate in current hp.
Original code will just overwrite any possible optimizer and learning rate settings already in hp so that every model needs to search from a preset optimizer and learning rate space even if you set these in elsewhere such as tuners/task_specific.py.

It could be better to serialize optimizer settings, but where to put the serialization operations will be the next problem.

<!-- STEP 4: If the pull request is in progress, click the down green arrow to select "Create Draft Pull Request", and click the button. If the pull request is ready to be reviewed, click "Create Pull Request" button directly. -->
