### PR TITLE
Fixed: #1773 Incorrect output with verbose=0

### DIFF
--- a/autokeras/engine/tuner.py
+++ b/autokeras/engine/tuner.py
@@ -216,6 +216,7 @@ class AutoTuner(keras_tuner.engine.tuner.Tuner):
                 copied_fit_kwargs.pop("validation_data")
 
             self.hypermodel.set_fit_args(0, epochs=copied_fit_kwargs["epochs"])
+            copied_fit_kwargs["verbose"] = verbose
             pipeline, model, history = self.final_fit(**copied_fit_kwargs)
         else:
             # TODO: Add return history functionality in Keras Tuner


### PR DESCRIPTION
### Which issue(s) does this Pull Request fix?
resolves #1773

### Details of the Pull Request
`AutoTuner.final_fit()` did not use the `verbose` argument passed to the `AutoModel.fit()` and always used defalult value `verbose=1`
